### PR TITLE
3D shear nonlinearity

### DIFF
--- a/for/CompDam_DGD.for
+++ b/for/CompDam_DGD.for
@@ -272,8 +272,12 @@ Subroutine CompDam(  &
   sv = loadStateVars(nstatev, stateOld(km,:), m)
 
   ! The sign of the change in shear strain, used in the shear nonlinearity subroutine. Previously was a state variable.
-  If (m%shearNonlinearity) sv%d_eps12 = Sign(one, (F(1,1)*F(1,2) + F(2,1)*F(2,2) + F(3,2)*F(3,1)) - &
-                                          (F_old(1,1)*F_old(1,2) + F_old(2,1)*F_old(2,2) + F_old(3,2)*F_old(3,1)))
+  If (m%shearNonlinearity12) Then
+    sv%d_eps12 = Sign(one, (F(1,1)*F(1,2) + F(2,1)*F(2,2) + F(3,2)*F(3,1)) - (F_old(1,1)*F_old(1,2) + F_old(2,1)*F_old(2,2) + F_old(3,2)*F_old(3,1)))
+  End If
+  If (m%shearNonlinearity13) Then
+    sv%d_eps13 = Sign(one, (F(1,1)*F(1,3) + F(2,1)*F(2,3) + F(3,1)*F(3,3)) - (F_old(1,1)*F_old(1,3) + F_old(2,1)*F_old(2,3) + F_old(3,2)*F_old(3,3)))
+  End If
 
   ! -------------------------------------------------------------------- !
   !    Define the characteristic element lengths                         !

--- a/for/DGD.for
+++ b/for/DGD.for
@@ -325,6 +325,7 @@ Contains
         sv%d2    = 1.d-8 ! Used as a flag to call DGDEvolve
         sv%alpha = alpha_test
         Call log%info('DGDInit found FIm > one. Matrix damage initiated.')
+        Call log%debug('alpha = ' // trim(str(sv%alpha)))
       End If
     End If
 
@@ -639,8 +640,11 @@ Contains
         End If
 
         ! Calculate the sign of the change in shear strain (for shear nonlinearity subroutine)
-        If (m%shearNonlinearity .AND. Q == 2) Then
+        If (m%shearNonlinearity12 .AND. Q == 2) Then
            sv%d_eps12_temp = Sign(one, (F(1,1)*F_bulk(1,2) + F(2,1)*F_bulk(2,2) + F_bulk(3,2)*F(3,1)) - (F_old(1,1)*sv%Fb1 + F_old(2,1)*sv%Fb2 + sv%Fb3*F_old(3,1)))
+        End If
+        If (m%shearNonlinearity13 .AND. Q == 3) Then
+           sv%d_eps13_temp = Sign(one, (F(1,1)*F_bulk(1,3) + F(2,1)*F_bulk(2,3) + F_bulk(3,1)*F(3,3)) - (F_old(1,1)*sv%Fb1 + F_old(2,1)*sv%Fb2 + F_old(3,2)*sv%Fb3))
         End If
 
         ! Compute the Green-Lagrange strain tensor for the bulk material: eps
@@ -1435,10 +1439,15 @@ Contains
     Else
       write(101,"(A)") '    "matrixDam": False,'
     End If
-    If (m%shearNonlinearity) Then
-      write(101,"(A)") '    "shearNonlinearity": True,'
+    If (m%shearNonlinearity12) Then
+      write(101,"(A)") '    "shearNonlinearity12": True,'
     Else
-      write(101,"(A)") '    "shearNonlinearity": False,'
+      write(101,"(A)") '    "shearNonlinearity12": False,'
+    End If
+    If (m%shearNonlinearity13) Then
+      write(101,"(A)") '    "shearNonlinearity13": True,'
+    Else
+      write(101,"(A)") '    "shearNonlinearity13": False,'
     End If
     If (m%fiberTenDam) Then
       write(101,"(A)") '    "fiberTenDam": True,'

--- a/for/matProp.for
+++ b/for/matProp.for
@@ -59,7 +59,14 @@ Module matProp_Mod
     Double Precision :: thickness
 
     ! Flags for features
-    Logical :: matrixDam, shearNonlinearity, schapery, fiberTenDam, fiberCompDamBL, fiberCompDamFKT, friction
+    Logical :: matrixDam
+    Logical :: shearNonlinearity12
+    Logical :: shearNonlinearity13
+    Logical :: schapery
+    Logical :: fiberTenDam
+    Logical :: fiberCompDamBL
+    Logical :: fiberCompDamFKT
+    Logical :: friction
 
   End Type matProps
 
@@ -418,15 +425,28 @@ Contains
 
               Case (2)
                 If (featureFlags(j:j) == '1') Then
-                  m%shearNonlinearity = .TRUE.
+                  m%shearNonlinearity12 = .TRUE.
+                  m%shearNonlinearity13 = .FALSE.
                   m%schapery = .FALSE.
-                  Call log%info("loadMatProps: Shear nonlinearity ENABLED")
+                  Call log%info("loadMatProps: Shear nonlinearity (1-2 plane) ENABLED")
                 Else If (featureFlags(j:j) == '2') Then
-                  m%shearNonlinearity = .FALSE.
+                  m%shearNonlinearity12 = .FALSE.
+                  m%shearNonlinearity13 = .FALSE.
                   m%schapery = .TRUE.
                   Call log%info("loadMatProps: Schapery micro-damage ENABLED")
+                Else If (featureFlags(j:j) == '3') Then
+                  m%shearNonlinearity12 = .TRUE.
+                  m%shearNonlinearity13 = .TRUE.
+                  m%schapery = .FALSE.
+                  Call log%info("loadMatProps: Shear nonlinearity (3-D) ENABLED")
+                Else If (featureFlags(j:j) == '4') Then
+                  m%shearNonlinearity12 = .FALSE.
+                  m%shearNonlinearity13 = .TRUE.
+                  m%schapery = .FALSE.
+                  Call log%info("loadMatProps: Shear nonlinearity (1-3 plane) ENABLED")
                 Else
-                  m%shearNonlinearity = .FALSE.
+                  m%shearNonlinearity12 = .FALSE.
+                  m%shearNonlinearity13 = .FALSE.
                   m%schapery = .FALSE.
                   Call log%info("loadMatProps: pre-peak nonlinearity DISABLED")
                 End If
@@ -790,7 +810,7 @@ Contains
     End If
 
     ! Check if shear nonlinearity properties have been defined
-    If (m%shearNonlinearity) Then
+    If (m%shearNonlinearity12 .OR. m%shearNonlinearity13) Then
       If (.NOT. m%aPL_def) Call log%error('PROPERTY ERROR: Some shear-nonlinearity properties are missing. Must define a value for alpha_PL.')
       If (.NOT. m%nPL_def) Call log%error('PROPERTY ERROR: Some shear-nonlinearity properties are missing. Must define a value for n_PL.')
       Call log%info('PROPERTY: Shear-nonlinearity properties have been defined')
@@ -844,7 +864,7 @@ Contains
       If (.NOT. m%SL_def) Call log%error('PROPERTY ERROR: Some fiber compression damage properties are missing (FKT model). Must define a value for SL.')
 
       ! Make sure shear nonlinearity is enabled
-      If (.NOT. m%shearNonlinearity) Call log%error('PROPERTY ERROR: Shear-nonlinearity must be enabled with fiber compression damage FKT.')
+      If (.NOT. m%shearNonlinearity12) Call log%error('PROPERTY ERROR: In-plane shear-nonlinearity must be enabled with fiber compression damage FKT.')
 
       Call log%info('PROPERTY: fiber compression damage FKT (model 3) properties have been defined')
     Else

--- a/for/plasticity.for
+++ b/for/plasticity.for
@@ -29,7 +29,7 @@ Contains
       use_temporary_sv = .FALSE.
     End If
 
-    If (m%shearNonlinearity) Then
+    If (m%shearNonlinearity12) Then
       If (use_temporary_sv) Then
         Call ro_plasticity(two*eps(1,2), sv%d_eps12_temp, m%G12, m%aPL, m%nPL, sv%Plas12_temp, sv%Inel12_temp)
         eps(1,2) = eps(1,2) - sv%Plas12_temp/two
@@ -38,6 +38,16 @@ Contains
         Call ro_plasticity(two*eps(1,2), sv%d_eps12, m%G12, m%aPL, m%nPL, sv%Plas12, sv%Inel12)
         eps(1,2) = eps(1,2) - sv%Plas12/two
         eps(2,1) = eps(1,2)
+      End IF
+    Else If (m%shearNonlinearity13) Then
+      If (use_temporary_sv) Then
+        Call ro_plasticity(two*eps(1,3), sv%d_eps13_temp, m%G13, m%aPL, m%nPL, sv%Plas13_temp, sv%Inel13_temp)
+        eps(1,3) = eps(1,3) - sv%Plas13_temp/two
+        eps(3,1) = eps(1,3)
+      Else
+        Call ro_plasticity(two*eps(1,3), sv%d_eps13, m%G13, m%aPL, m%nPL, sv%Plas13, sv%Inel13)
+        eps(1,3) = eps(1,3) - sv%Plas13/two
+        eps(3,1) = eps(1,3)
       End IF
     ! Else If (m%other_plasticity_model)
       ! TODO

--- a/for/vumatWrapper.for
+++ b/for/vumatWrapper.for
@@ -246,8 +246,8 @@ Contains
       stress(3) = CauchyABQ(3,3)
       stress(4) = CauchyABQ(1,2)
       If (nshr > 1) Then
-        stress(5) = CauchyABQ(2,3)
-        stress(6) = CauchyABQ(3,1)
+        stress(5) = CauchyABQ(3,1)
+        stress(6) = CauchyABQ(2,3)
       End If
     Else
       stress(3) = CauchyABQ(1,2)

--- a/tests/test_C3D8R_UMAT_elastic_matrixTension.inp
+++ b/tests/test_C3D8R_UMAT_elastic_matrixTension.inp
@@ -54,7 +54,7 @@
                0, ,  <length>,  ,  ,  ,  ,  ,
 **
 *Depvar, delete=11
-  33,
+  28,
   1, CDM_d2
   2, CDM_Fb1
   3, CDM_Fb2
@@ -74,22 +74,16 @@
  17, CDM_FIfC
  18, CDM_d1T
  19, CDM_d1C
- 20, CDM_20
- 21, CDM_21
- 22, CDM_22
- 23, CDM_23
- 24, CDM_24
- 25, CDM_DIRECT11
- 26, CDM_DIRECT21
- 27, CDM_DIRECT31
- 28, CDM_DIRECT12
- 29, CDM_DIRECT22
- 30, CDM_DIRECT32
- 31, CDM_DIRECT13
- 32, CDM_DIRECT23
- 33, CDM_DIRECT33
+ 20, CDM_DIRECT11
+ 21, CDM_DIRECT21
+ 22, CDM_DIRECT31
+ 23, CDM_DIRECT12
+ 24, CDM_DIRECT22
+ 25, CDM_DIRECT32
+ 26, CDM_DIRECT13
+ 27, CDM_DIRECT23
+ 28, CDM_DIRECT33
 *User defined field
-** *Characteristic Length, definition=USER, components=3
 **
 ** INITIAL CONDITIONS
 **
@@ -97,8 +91,7 @@
 ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
 0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
 0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0
 *Initial Conditions, Type=Field, Variable=1
 GLOBAL,  0.d0
 **

--- a/tests/test_C3D8R_UMAT_fiberCompression_FKT.inp
+++ b/tests/test_C3D8R_UMAT_fiberCompression_FKT.inp
@@ -94,7 +94,7 @@ stepDuration = 1.0
     1200.1,      ,         ,          ,     ,         <wkb>,    ,         0.3
 **
 *Depvar
-  33,
+  35,
   1, CDM_d2
   2, CDM_Fb1
   3, CDM_Fb2
@@ -114,20 +114,22 @@ stepDuration = 1.0
  17, CDM_FIfC
  18, CDM_d1T
  19, CDM_d1C
- 20, CDM_phi
- 21, CDM_gamma
- 22, CDM_Fm1
- 23, CDM_Fm2
- 24, CDM_Fm3
- 25, CDM_DIRECT11
- 26, CDM_DIRECT21
- 27, CDM_DIRECT31
- 28, CDM_DIRECT12
- 29, CDM_DIRECT22
- 30, CDM_DIRECT32
- 31, CDM_DIRECT13
- 32, CDM_DIRECT23
- 33, CDM_DIRECT33
+ 20, CDM_Plas13
+ 21, CDM_Inel13
+ 22, CDM_phi
+ 23, CDM_gamma
+ 24, CDM_Fm1
+ 25, CDM_Fm2
+ 26, CDM_Fm3
+ 27, CDM_DIRECT11
+ 28, CDM_DIRECT21
+ 29, CDM_DIRECT31
+ 30, CDM_DIRECT12
+ 31, CDM_DIRECT22
+ 32, CDM_DIRECT32
+ 33, CDM_DIRECT13
+ 34, CDM_DIRECT23
+ 35, CDM_DIRECT33
 *User defined field
 **
 ** INITIAL CONDITIONS
@@ -135,9 +137,9 @@ stepDuration = 1.0
 *Initial Conditions, Type=Solution
   Part-1-1.all,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
   0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
-  0.d0,  0.d0,  0.d0,  0.d0,  5.236d-2,  0.d0,  0.d0,  0.d0,
+  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0, 5.236d-2,  0.d0,
   0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0
 *Initial Conditions, Type=Field, Variable=1
   Part-1-1.GLOBAL,  0.d0
 **

--- a/tests/test_C3D8R_UMAT_matrixTension.inp
+++ b/tests/test_C3D8R_UMAT_matrixTension.inp
@@ -70,7 +70,7 @@
     1200.1,      ,         ,          ,     0.2618,   0.1,      0.038,    0
 **
 *Depvar, delete=11
-  33,
+  28,
   1, CDM_d2
   2, CDM_Fb1
   3, CDM_Fb2
@@ -90,20 +90,15 @@
  17, CDM_FIfC
  18, CDM_d1T
  19, CDM_d1C
- 20, CDM_20
- 21, CDM_21
- 22, CDM_22
- 23, CDM_23
- 24, CDM_24
- 25, CDM_DIRECT11
- 26, CDM_DIRECT21
- 27, CDM_DIRECT31
- 28, CDM_DIRECT12
- 29, CDM_DIRECT22
- 30, CDM_DIRECT32
- 31, CDM_DIRECT13
- 32, CDM_DIRECT23
- 33, CDM_DIRECT33
+ 20, CDM_DIRECT11
+ 21, CDM_DIRECT21
+ 22, CDM_DIRECT31
+ 23, CDM_DIRECT12
+ 24, CDM_DIRECT22
+ 25, CDM_DIRECT32
+ 26, CDM_DIRECT13
+ 27, CDM_DIRECT23
+ 28, CDM_DIRECT33
 *User defined field
 **
 ** INITIAL CONDITIONS
@@ -112,8 +107,7 @@
 ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
 0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
 0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0
 *Initial Conditions, Type=Field, Variable=1
 GLOBAL,  0.d0
 **

--- a/tests/test_C3D8R_UMAT_nonlinearShear12.inp
+++ b/tests/test_C3D8R_UMAT_nonlinearShear12.inp
@@ -1,0 +1,597 @@
+*Heading
+ Single element test for simple shear loading
+**
+*Parameter
+ length = 0.2
+ displacement = 0.02
+**
+** NODES
+**
+*NODE, NSET=GLOBAL
+      1,            0.,            0.,            0.
+      2,      <length>,            0.,            0.
+      3,      <length>,      <length>,            0.
+      4,            0.,      <length>,            0.
+      5,            0.,            0.,      <length>
+      6,      <length>,            0.,      <length>
+      7,      <length>,      <length>,      <length>
+      8,            0.,      <length>,      <length>
+*NSET, NSET=X+
+  2, 3, 6, 7
+*NSET, NSET=X-
+  1, 4, 5, 8
+*NSET, NSET=Y+
+  3, 4, 7, 8
+*NSET, NSET=Y-
+  1, 2, 5, 6
+*NSET, NSET=Z+
+  5, 6, 7, 8
+*NSET, NSET=Z-
+  1, 2, 3, 4
+**
+** ELEMENTS
+**
+*ELEMENT, TYPE=C3D8R, ELSET=ALL_ELEMS
+  1, 1, 2, 3, 4, 5, 6, 7, 8
+**
+** PROPERTIES
+**
+*Orientation, name=Ori-1
+ 1., 0., 0., 0., 1., 0.
+3, 0.
+*SOLID SECTION, ELSET=ALL_ELEMS, MATERIAL=IM7-8552, controls=C-1, Orientation=Ori-1
+*Section Controls, name=C-1, hourglass=ENHANCED
+**
+** MATERIALS
+**
+*Material, name=IM7-8552
+*Density
+ 1.59d-05,
+*User material, constants=4
+** 1              2                  3          4
+** feature flags, , thickness, 4, 5, 6, 7, 8
+          110000, ,  <length>,  ,  ,  ,  ,  ,
+**
+*Depvar, delete=11
+  28,
+  1, CDM_d2
+  2, CDM_Fb1
+  3, CDM_Fb2
+  4, CDM_Fb3
+  5, CDM_B
+  6, CDM_Lc1
+  7, CDM_Lc2
+  8, CDM_Lc3
+  9, CDM_FIm
+ 10, CDM_alpha
+ 11, CDM_STATUS
+ 12, CDM_Plas12
+ 13, CDM_Inel12
+ 14, CDM_FIfT
+ 15, CDM_slide1
+ 16, CDM_slide2
+ 17, CDM_FIfC
+ 18, CDM_d1T
+ 19, CDM_d1C
+ 20, CDM_DIRECT11
+ 21, CDM_DIRECT21
+ 22, CDM_DIRECT31
+ 23, CDM_DIRECT12
+ 24, CDM_DIRECT22
+ 25, CDM_DIRECT32
+ 26, CDM_DIRECT13
+ 27, CDM_DIRECT23
+ 28, CDM_DIRECT33
+*User defined field
+**
+** INITIAL CONDITIONS
+**
+*Initial Conditions, Type=Solution
+ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Initial Conditions, Type=Field, Variable=1
+GLOBAL,  0.d0
+**
+** Boundary conditions
+**
+*BOUNDARY
+  Y-, 1, 2, 0
+  Y+, 1, 2, 0
+  Z-, 3, 3, 0
+**
+*Equation
+ 2
+ 5, 3, 1., 6, 3, -1.
+ 2
+ 6, 3, 1., 7, 3, -1.
+ 2
+ 7, 3, 1., 8, 3, -1.
+**
+*Amplitude, name=Step1, definition=SMOOTH STEP
+0., 0.0,  0.1, 0.2
+*Amplitude, name=Step2, definition=SMOOTH STEP
+0., 0.2, 0.05, 0.1
+**
+*Amplitude, name=Step3, definition=SMOOTH STEP
+0., 0.1,  0.1, 0.3
+*Amplitude, name=Step4, definition=SMOOTH STEP
+0., 0.3, 0.05, 0.2
+**
+*Amplitude, name=Step5, definition=SMOOTH STEP
+0., 0.2,  0.1, 0.4
+*Amplitude, name=Step6, definition=SMOOTH STEP
+0., 0.4, 0.05, 0.3
+**
+*Amplitude, name=Step7, definition=SMOOTH STEP
+0., 0.3,  0.1, 0.5
+*Amplitude, name=Step8, definition=SMOOTH STEP
+0., 0.5, 0.05, 0.4
+**
+*Amplitude, name=Step9, definition=SMOOTH STEP
+0., 0.4,  0.1, 0.6
+*Amplitude, name=Step10, definition=SMOOTH STEP
+0., 0.6, 0.05, 0.5
+**
+*Amplitude, name=Step11, definition=SMOOTH STEP
+0., 0.5,  0.1, 0.7
+*Amplitude, name=Step12, definition=SMOOTH STEP
+0., 0.7, 0.05, 0.6
+**
+*Amplitude, name=Step13, definition=SMOOTH STEP
+0., 0.6,  0.1, 0.8
+*Amplitude, name=Step14, definition=SMOOTH STEP
+0., 0.8, 0.05, 0.7
+**
+*Amplitude, name=Step15, definition=SMOOTH STEP
+0., 0.7,  0.1, 0.9
+*Amplitude, name=Step16, definition=SMOOTH STEP
+0., 0.9, 0.05, 0.8
+**
+*Amplitude, name=Step17, definition=SMOOTH STEP
+0., 0.8,  0.1, 1.0
+*Amplitude, name=Step18, definition=SMOOTH STEP
+0., 1.0, 0.05, 0.0
+**
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step1
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step2
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step3
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step4
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step5
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step6
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step7
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step8
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step9
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step10
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step11
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step12
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step13
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step14
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step15
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step16
+ Y+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step17
+ Y+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Y+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step18
+ Y+, 1, 1, <displacement>
+*END STEP

--- a/tests/test_C3D8R_UMAT_nonlinearShear12_expected.py
+++ b/tests/test_C3D8R_UMAT_nonlinearShear12_expected.py
@@ -1,0 +1,75 @@
+parameters = {
+	"results": [
+        {
+            "type": "max",
+            "step": "Step-7",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 90.65,
+            "tolerance": 0.2
+        },
+        {
+            "type": "max",
+            "step": "Step-9",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 91.08,
+            "tolerance": 0.2
+        },
+        {
+            "type": "max",
+            "step": "Step-11",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 79.96,
+            "tolerance": 2.0
+        },
+        {
+            "type": "max",
+            "step": "Step-17",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d1T",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "max",
+            "step": "Step-17",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d1C",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 2.0
+        }
+	]
+}

--- a/tests/test_C3D8R_UMAT_nonlinearShear13.inp
+++ b/tests/test_C3D8R_UMAT_nonlinearShear13.inp
@@ -1,0 +1,601 @@
+*Heading
+ Single element test for simple shear loading
+**
+*Parameter
+ length = 0.2
+ displacement = 0.02
+**
+** NODES
+**
+*NODE, NSET=GLOBAL
+      1,            0.,            0.,            0.
+      2,      <length>,            0.,            0.
+      3,      <length>,      <length>,            0.
+      4,            0.,      <length>,            0.
+      5,            0.,            0.,      <length>
+      6,      <length>,            0.,      <length>
+      7,      <length>,      <length>,      <length>
+      8,            0.,      <length>,      <length>
+*NSET, NSET=X+
+  2, 3, 6, 7
+*NSET, NSET=X-
+  1, 4, 5, 8
+*NSET, NSET=Y+
+  3, 4, 7, 8
+*NSET, NSET=Y-
+  1, 2, 5, 6
+*NSET, NSET=Z+
+  5, 6, 7, 8
+*NSET, NSET=Z-
+  1, 2, 3, 4
+**
+** ELEMENTS
+**
+*ELEMENT, TYPE=C3D8R, ELSET=ALL_ELEMS
+  1, 1, 2, 3, 4, 5, 6, 7, 8
+**
+** PROPERTIES
+**
+*Orientation, name=Ori-1
+ 1., 0., 0., 0., 1., 0.
+3, 0.
+*SOLID SECTION, ELSET=ALL_ELEMS, MATERIAL=IM7-8552, controls=C-1, Orientation=Ori-1
+*Section Controls, name=C-1, hourglass=ENHANCED
+**
+** MATERIALS
+**
+*Material, name=IM7-8552
+*Density
+ 1.59d-05,
+*User material, constants=4
+** 1              2                  3          4
+** feature flags, , thickness, 4, 5, 6, 7, 8
+          140000, ,  <length>,  ,  ,  ,  ,  ,
+**
+*Depvar, delete=11
+  30,
+  1, CDM_d2
+  2, CDM_Fb1
+  3, CDM_Fb2
+  4, CDM_Fb3
+  5, CDM_B
+  6, CDM_Lc1
+  7, CDM_Lc2
+  8, CDM_Lc3
+  9, CDM_FIm
+ 10, CDM_alpha
+ 11, CDM_STATUS
+ 12, CDM_Plas12
+ 13, CDM_Inel12
+ 14, CDM_FIfT
+ 15, CDM_slide1
+ 16, CDM_slide2
+ 17, CDM_FIfC
+ 18, CDM_d1T
+ 19, CDM_d1C
+ 20, CDM_Plas13
+ 21, CDM_Inel13
+ 22, CDM_DIRECT11
+ 23, CDM_DIRECT21
+ 24, CDM_DIRECT31
+ 25, CDM_DIRECT12
+ 26, CDM_DIRECT22
+ 27, CDM_DIRECT32
+ 28, CDM_DIRECT13
+ 29, CDM_DIRECT23
+ 30, CDM_DIRECT33
+*User defined field
+**
+** INITIAL CONDITIONS
+**
+*Initial Conditions, Type=Solution
+ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  90,     1,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Initial Conditions, Type=Field, Variable=1
+GLOBAL,  0.d0
+**
+** Boundary conditions
+**
+*BOUNDARY
+  Y-, 2, 2, 0
+  Z+, 1, 1, 0
+  Z+, 3, 3, 0
+  Z-, 1, 1, 0
+  Z-, 3, 3, 0
+**
+*Equation
+ 2
+ 3, 2, 1., 4, 2, -1.
+ 2
+ 4, 2, 1., 7, 2, -1.
+ 2
+ 7, 2, 1., 8, 2, -1.
+**
+*Amplitude, name=Step1, definition=SMOOTH STEP
+0., 0.0,  0.1, 0.2
+*Amplitude, name=Step2, definition=SMOOTH STEP
+0., 0.2, 0.05, 0.1
+**
+*Amplitude, name=Step3, definition=SMOOTH STEP
+0., 0.1,  0.1, 0.3
+*Amplitude, name=Step4, definition=SMOOTH STEP
+0., 0.3, 0.05, 0.2
+**
+*Amplitude, name=Step5, definition=SMOOTH STEP
+0., 0.2,  0.1, 0.4
+*Amplitude, name=Step6, definition=SMOOTH STEP
+0., 0.4, 0.05, 0.3
+**
+*Amplitude, name=Step7, definition=SMOOTH STEP
+0., 0.3,  0.1, 0.5
+*Amplitude, name=Step8, definition=SMOOTH STEP
+0., 0.5, 0.05, 0.4
+**
+*Amplitude, name=Step9, definition=SMOOTH STEP
+0., 0.4,  0.1, 0.6
+*Amplitude, name=Step10, definition=SMOOTH STEP
+0., 0.6, 0.05, 0.5
+**
+*Amplitude, name=Step11, definition=SMOOTH STEP
+0., 0.5,  0.1, 0.7
+*Amplitude, name=Step12, definition=SMOOTH STEP
+0., 0.7, 0.05, 0.6
+**
+*Amplitude, name=Step13, definition=SMOOTH STEP
+0., 0.6,  0.1, 0.8
+*Amplitude, name=Step14, definition=SMOOTH STEP
+0., 0.8, 0.05, 0.7
+**
+*Amplitude, name=Step15, definition=SMOOTH STEP
+0., 0.7,  0.1, 0.9
+*Amplitude, name=Step16, definition=SMOOTH STEP
+0., 0.9, 0.05, 0.8
+**
+*Amplitude, name=Step17, definition=SMOOTH STEP
+0., 0.8,  0.1, 1.0
+*Amplitude, name=Step18, definition=SMOOTH STEP
+0., 1.0, 0.05, 0.0
+**
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step1
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step2
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step3
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step4
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step5
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step6
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step7
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step8
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step9
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step10
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step11
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step12
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step13
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step14
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step15
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step16
+ Z+, 1, 1, <displacement>
+*END STEP
+*************************************************************
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.1, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step17
+ Z+, 1, 1, <displacement>
+*END STEP
+*STEP, nlgeom=YES, inc=1000
+*Dynamic, application=QUASI-STATIC, initial=NO
+ 0.001, 0.05, 5.e-6, 0.001
+**
+** OUTPUT
+**
+*OUTPUT, FIELD, frequency=1
+*ELEMENT OUTPUT
+ SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step18
+ Z+, 1, 1, <displacement>
+*END STEP

--- a/tests/test_C3D8R_UMAT_nonlinearShear13_expected.py
+++ b/tests/test_C3D8R_UMAT_nonlinearShear13_expected.py
@@ -1,0 +1,75 @@
+parameters = {
+	"results": [
+        {
+            "type": "max",
+            "step": "Step-7",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 90.65,
+            "tolerance": 0.2
+        },
+        {
+            "type": "max",
+            "step": "Step-9",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 91.08,
+            "tolerance": 0.2
+        },
+        {
+            "type": "max",
+            "step": "Step-11",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 79.96,
+            "tolerance": 2.0
+        },
+        {
+            "type": "max",
+            "step": "Step-17",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d1T",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "max",
+            "step": "Step-17",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d1C",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 2.0
+        }
+	]
+}

--- a/tests/test_C3D8R_UMAT_simpleShear12.inp
+++ b/tests/test_C3D8R_UMAT_simpleShear12.inp
@@ -54,7 +54,7 @@
           100000, ,  <length>,  ,  ,  ,  ,  ,
 **
 *Depvar, delete=11
-  33,
+  28,
   1, CDM_d2
   2, CDM_Fb1
   3, CDM_Fb2
@@ -74,20 +74,15 @@
  17, CDM_FIfC
  18, CDM_d1T
  19, CDM_d1C
- 20, CDM_20
- 21, CDM_21
- 22, CDM_22
- 23, CDM_23
- 24, CDM_24
- 25, CDM_DIRECT11
- 26, CDM_DIRECT21
- 27, CDM_DIRECT31
- 28, CDM_DIRECT12
- 29, CDM_DIRECT22
- 30, CDM_DIRECT32
- 31, CDM_DIRECT13
- 32, CDM_DIRECT23
- 33, CDM_DIRECT33
+ 20, CDM_DIRECT11
+ 21, CDM_DIRECT21
+ 22, CDM_DIRECT31
+ 23, CDM_DIRECT12
+ 24, CDM_DIRECT22
+ 25, CDM_DIRECT32
+ 26, CDM_DIRECT13
+ 27, CDM_DIRECT23
+ 28, CDM_DIRECT33
 *User defined field
 **
 ** INITIAL CONDITIONS
@@ -96,8 +91,7 @@
 ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
 0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
 0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0
 *Initial Conditions, Type=Field, Variable=1
 GLOBAL,  0.d0
 **

--- a/tests/test_C3D8R_fiberCompression_FKT.inp
+++ b/tests/test_C3D8R_fiberCompression_FKT.inp
@@ -95,31 +95,33 @@ stepDuration = 0.1
     1200.1,      ,         ,          ,     ,         <wkb>,    ,         0.3
 **
 *Depvar
-  24,
-  1, CDM_d2
-  2, CDM_Fb1
-  3, CDM_Fb2
-  4, CDM_Fb3
-  5, CDM_B
-  6, CDM_Lc1
-  7, CDM_Lc2
-  8, CDM_Lc3
-  9, CDM_FIm
- 10, CDM_alpha
- 11, CDM_STATUS
- 12, CDM_Plas12
- 13, CDM_Inel12
- 14, CDM_FIfT
- 15, CDM_slide1
- 16, CDM_slide2
- 17, CDM_FIfC
- 18, CDM_d1T
- 19, CDM_d1C
- 20, CDM_phi
- 21, CDM_gamma
- 22, CDM_Fm1
- 23, CDM_Fm2
- 24, CDM_Fm3
+26,
+ 1, CDM_d2
+ 2, CDM_Fb1
+ 3, CDM_Fb2
+ 4, CDM_Fb3
+ 5, CDM_B
+ 6, CDM_Lc1
+ 7, CDM_Lc2
+ 8, CDM_Lc3
+ 9, CDM_FIm
+10, CDM_alpha
+11, CDM_STATUS
+12, CDM_Plas12
+13, CDM_Inel12
+14, CDM_FIfT
+15, CDM_slide1
+16, CDM_slide2
+17, CDM_FIfC
+18, CDM_d1T
+19, CDM_d1C
+20, CDM_Plas13
+21, CDM_Inel13
+22, CDM_phi
+23, CDM_gamma
+24, CDM_Fm1
+25, CDM_Fm2
+26, CDM_Fm3
 *Characteristic Length, definition=USER, components=3
 **
 ** INITIAL CONDITIONS
@@ -128,7 +130,7 @@ stepDuration = 0.1
   Part-1-1.all,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
   0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
   0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-  0.d0,
+  0.d0,  0.d0,  0.d0
 ** ----------------------------------------------------------------
 **
 ** STEP: Step-1

--- a/tests/test_C3D8R_fiberCompression_FKT_FN.inp
+++ b/tests/test_C3D8R_fiberCompression_FKT_FN.inp
@@ -95,31 +95,33 @@ stepDuration = 0.1
     1200.1,      ,         ,          ,     10.0,     <wkb>,    ,         0.3
 **
 *Depvar
-  24,
-  1, CDM_d2
-  2, CDM_Fb1
-  3, CDM_Fb2
-  4, CDM_Fb3
-  5, CDM_B
-  6, CDM_Lc1
-  7, CDM_Lc2
-  8, CDM_Lc3
-  9, CDM_FIm
- 10, CDM_alpha
- 11, CDM_STATUS
- 12, CDM_Plas12
- 13, CDM_Inel12
- 14, CDM_FIfT
- 15, CDM_slide1
- 16, CDM_slide2
- 17, CDM_FIfC
- 18, CDM_d1T
- 19, CDM_d1C
- 20, CDM_phi
- 21, CDM_gamma
- 22, CDM_Fm1
- 23, CDM_Fm2
- 24, CDM_Fm3
+26,
+ 1, CDM_d2
+ 2, CDM_Fb1
+ 3, CDM_Fb2
+ 4, CDM_Fb3
+ 5, CDM_B
+ 6, CDM_Lc1
+ 7, CDM_Lc2
+ 8, CDM_Lc3
+ 9, CDM_FIm
+10, CDM_alpha
+11, CDM_STATUS
+12, CDM_Plas12
+13, CDM_Inel12
+14, CDM_FIfT
+15, CDM_slide1
+16, CDM_slide2
+17, CDM_FIfC
+18, CDM_d1T
+19, CDM_d1C
+20, CDM_Plas13
+21, CDM_Inel13
+22, CDM_phi
+23, CDM_gamma
+24, CDM_Fm1
+25, CDM_Fm2
+26, CDM_Fm3
 *Characteristic Length, definition=USER, components=3
 **
 ** INITIAL CONDITIONS
@@ -128,7 +130,7 @@ stepDuration = 0.1
   Part-1-1.all,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
   0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,  0.d0,
   0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
-  0.d0,
+  0.d0,  0.d0,  0.d0
 ** ----------------------------------------------------------------
 **
 ** STEP: Step-1

--- a/tests/test_C3D8R_nonlinearShear13.inp
+++ b/tests/test_C3D8R_nonlinearShear13.inp
@@ -1,0 +1,545 @@
+*Heading
+ Single element test for matrix nonlinear shear response
+**
+*Parameter
+ length = 0.2
+ shear_displacement = 0.02
+ shear_displacement_half = shear_displacement/2.
+**
+** NODES
+**
+*NODE, NSET=GLOBAL
+      1,            0.,            0.,            0.
+      2,      <length>,            0.,            0.
+      3,      <length>,      <length>,            0.
+      4,            0.,      <length>,            0.
+      5,            0.,            0.,      <length>
+      6,      <length>,            0.,      <length>
+      7,      <length>,      <length>,      <length>
+      8,            0.,      <length>,      <length>
+*NSET, NSET=X+
+  2, 3, 6, 7
+*NSET, NSET=X-
+  1, 4, 5, 8
+*NSET, NSET=Y+
+  3, 4, 7, 8
+*NSET, NSET=Y-
+  1, 2, 5, 6
+*NSET, NSET=Z+
+  5, 6, 7, 8
+*NSET, NSET=Z-
+  1, 2, 3, 4
+**
+** ELEMENTS
+**
+*ELEMENT, TYPE=C3D8R, ELSET=ALL_ELEMS
+  1, 1, 2, 3, 4, 5, 6, 7, 8
+**
+** PROPERTIES
+**
+*SOLID SECTION, ELSET=ALL_ELEMS, MATERIAL=IM7-8552
+**
+** MATERIALS
+**
+*Material, name=IM7-8552
+*Density
+ 1.59d-05,
+*User material, constants=4
+** 1              2                  3          4
+** feature flags, , thickness, 4, 5, 6, 7, 8
+         140001,  ,  <length>,  ,  ,  ,  ,  ,
+*Depvar, delete=11
+ 21,
+ 1, CDM_d2
+ 2, CDM_Fb1
+ 3, CDM_Fb2
+ 4, CDM_Fb3
+ 5, CDM_B
+ 6, CDM_Lc1
+ 7, CDM_Lc2
+ 8, CDM_Lc3
+ 9, CDM_FIm
+10, CDM_alpha
+11, CDM_STATUS
+12, CDM_Plas12
+13, CDM_Inel12
+14, CDM_FIfT
+15, CDM_slide1
+16, CDM_slide2
+17, CDM_FIfC
+18, CDM_d1T
+19, CDM_d1C
+20, CDM_Plas13
+21, CDM_Inel13
+*Characteristic Length, definition=USER, components=3
+**
+** INITIAL CONDITIONS
+**
+*Initial Conditions, Type=Solution
+ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,       0.d0,  90,     1,  0.d0,  0.d0,  0.d0,  0.d0,  
+0.d0,       0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*BOUNDARY
+  Y-, 2, 2, 0
+  Z+, 1, 1, 0
+  Z+, 3, 3, 0
+  Z-, 1, 1, 0
+  Z-, 3, 3, 0
+**
+*Equation
+ 2
+ 3, 2, 1., 4, 2, -1.
+ 2
+ 4, 2, 1., 7, 2, -1.
+ 2
+ 7, 2, 1., 8, 2, -1.
+**
+*Amplitude, name=Step1, definition=SMOOTH STEP
+0., 0.0,  0.1, 0.2
+*Amplitude, name=Step2, definition=SMOOTH STEP
+0., 0.2, 0.05, 0.1
+**
+*Amplitude, name=Step3, definition=SMOOTH STEP
+0., 0.1,  0.1, 0.3
+*Amplitude, name=Step4, definition=SMOOTH STEP
+0., 0.3, 0.05, 0.2
+**
+*Amplitude, name=Step5, definition=SMOOTH STEP
+0., 0.2,  0.1, 0.4
+*Amplitude, name=Step6, definition=SMOOTH STEP
+0., 0.4, 0.05, 0.3
+**
+*Amplitude, name=Step7, definition=SMOOTH STEP
+0., 0.3,  0.1, 0.5
+*Amplitude, name=Step8, definition=SMOOTH STEP
+0., 0.5, 0.05, 0.4
+**
+*Amplitude, name=Step9, definition=SMOOTH STEP
+0., 0.4,  0.1, 0.6
+*Amplitude, name=Step10, definition=SMOOTH STEP
+0., 0.6, 0.05, 0.5
+**
+*Amplitude, name=Step11, definition=SMOOTH STEP
+0., 0.5,  0.1, 0.7
+*Amplitude, name=Step12, definition=SMOOTH STEP
+0., 0.7, 0.05, 0.6
+**
+*Amplitude, name=Step13, definition=SMOOTH STEP
+0., 0.6,  0.1, 0.8
+*Amplitude, name=Step14, definition=SMOOTH STEP
+0., 0.8, 0.05, 0.7
+**
+*Amplitude, name=Step15, definition=SMOOTH STEP
+0., 0.7,  0.1, 0.9
+*Amplitude, name=Step16, definition=SMOOTH STEP
+0., 0.9, 0.05, 0.8
+**
+*Amplitude, name=Step17, definition=SMOOTH STEP
+0., 0.8,  0.1, 1.0
+*Amplitude, name=Step18, definition=SMOOTH STEP
+0., 1.0, 0.05, 0.0
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step1
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step2
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step3
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step4
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step5
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step6
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step7
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step8
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step9
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step10
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step11
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step12
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step13
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step14
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step15
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step16
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step17
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step18
+ Z+, 1, 1, <shear_displacement>
+*END STEP

--- a/tests/test_C3D8R_nonlinearShear13_expected.py
+++ b/tests/test_C3D8R_nonlinearShear13_expected.py
@@ -1,0 +1,75 @@
+parameters = {
+"results": [
+        {
+            "type": "max",
+            "step": "Step-7",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 90.65,
+            "tolerance": 0.01
+        },
+        {
+            "type": "max",
+            "step": "Step-9",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 91.08,
+            "tolerance": 0.01
+        },
+        {
+            "type": "max",
+            "step": "Step-11",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 79.96,
+            "tolerance": 0.05
+        },
+        {
+            "type": "max",
+            "step": "Step-17",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d1T",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "max",
+            "step": "Step-17",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d1C",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.1
+        }
+	]
+}

--- a/tests/test_C3D8R_nonlinearShear13_loadReversal.inp
+++ b/tests/test_C3D8R_nonlinearShear13_loadReversal.inp
@@ -1,0 +1,246 @@
+*Heading
+ Single element test for matrix nonlinear shear response
+**
+*Parameter
+ length = 0.2
+ shear_displacement = 0.02
+ shear_displacement_half = shear_displacement/2.
+**
+** NODES
+**
+*NODE, NSET=GLOBAL
+      1,            0.,            0.,            0.
+      2,      <length>,            0.,            0.
+      3,      <length>,      <length>,            0.
+      4,            0.,      <length>,            0.
+      5,            0.,            0.,      <length>
+      6,      <length>,            0.,      <length>
+      7,      <length>,      <length>,      <length>
+      8,            0.,      <length>,      <length>
+*NSET, NSET=X+
+  2, 3, 6, 7
+*NSET, NSET=X-
+  1, 4, 5, 8
+*NSET, NSET=Y+
+  3, 4, 7, 8
+*NSET, NSET=Y-
+  1, 2, 5, 6
+*NSET, NSET=Z+
+  5, 6, 7, 8
+*NSET, NSET=Z-
+  1, 2, 3, 4
+**
+** ELEMENTS
+**
+*ELEMENT, TYPE=C3D8R, ELSET=ALL_ELEMS
+  1, 1, 2, 3, 4, 5, 6, 7, 8
+**
+** PROPERTIES
+**
+*SOLID SECTION, ELSET=ALL_ELEMS, MATERIAL=IM7-8552
+**
+** MATERIALS
+**
+*Material, name=IM7-8552
+*Density
+ 1.59d-05,
+*User material, constants=4
+** 1              2                  3          4
+** feature flags, , thickness, 4, 5, 6, 7, 8
+         040000,  ,  <length>,  ,  ,  ,  ,  ,
+*Depvar, delete=11
+ 21,
+ 1, CDM_d2
+ 2, CDM_Fb1
+ 3, CDM_Fb2
+ 4, CDM_Fb3
+ 5, CDM_B
+ 6, CDM_Lc1
+ 7, CDM_Lc2
+ 8, CDM_Lc3
+ 9, CDM_FIm
+10, CDM_alpha
+11, CDM_STATUS
+12, CDM_Plas12
+13, CDM_Inel12
+14, CDM_FIfT
+15, CDM_slide1
+16, CDM_slide2
+17, CDM_FIfC
+18, CDM_d1T
+19, CDM_d1C
+20, CDM_Plas13
+21, CDM_Inel13
+*Characteristic Length, definition=USER, components=3
+**
+** INITIAL CONDITIONS
+**
+*Initial Conditions, Type=Solution
+ALL_ELEMS,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,       0.d0,  90,     1,  0.d0,  0.d0,  0.d0,  0.d0,  
+0.d0,       0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*BOUNDARY
+  Y-, 2, 3, 0
+  Z+, 1, 1, 0
+  Z+, 3, 3, 0
+  Z-, 1, 1, 0
+  Z-, 3, 3, 0
+**
+*Equation
+ 2
+ 5, 3, 1., 6, 3, -1.
+ 2
+ 6, 3, 1., 7, 3, -1.
+ 2
+ 7, 3, 1., 8, 3, -1.
+**
+*Amplitude, name=Step1, definition=SMOOTH STEP
+0., 0.0,  0.1, 0.2
+*Amplitude, name=Step2, definition=SMOOTH STEP
+0., 0.2, 0.05, 0.1
+**
+*Amplitude, name=Step3, definition=SMOOTH STEP
+0., 0.1,  0.1, 0.4
+*Amplitude, name=Step4, definition=SMOOTH STEP
+0., 0.4, 0.05, 0.0
+**
+*Amplitude, name=Step5, definition=SMOOTH STEP
+0., 0.0,  0.1, -0.2
+*Amplitude, name=Step6, definition=SMOOTH STEP
+0., -0.2, 0.05, 0.2
+**
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step1
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step2
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step3
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step4
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*************************************************************
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.1, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U, RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step5
+ Z+, 1, 1, <shear_displacement>
+*END STEP
+*STEP, NLGEOM=YES
+*Dynamic, Explicit
+ , 0.05, ,
+**
+** OUTPUT
+**
+*OUTPUT, FIELD
+*ELEMENT OUTPUT
+  SDV, S, LE
+*Node Output
+ U, RF
+*OUTPUT, HISTORY, frequency=1
+*NODE OUTPUT, NSET=Z+
+ U,RF
+*ELEMENT OUTPUT, ELSET=ALL_ELEMS
+ SDV, S, LE
+**
+** LOADING
+**
+*Boundary, AMPLITUDE=Step6
+ Z+, 1, 1, <shear_displacement>
+*END STEP

--- a/tests/test_C3D8R_nonlinearShear13_loadReversal_expected.py
+++ b/tests/test_C3D8R_nonlinearShear13_loadReversal_expected.py
@@ -1,0 +1,39 @@
+parameters = {
+"results": [
+        {
+            "type": "min",
+            "step": "Step-4",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": -89,
+            "tolerance": 1.0
+        },
+        {
+            "type": "max",
+            "step": "Step-6",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 97.5,
+            "tolerance": 1.0
+        },
+        {
+            "type": "continuous",
+            "identifier":
+                {
+                    "symbol": "S13",
+                    "elset": "ALL_ELEMS",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.1
+        }
+    ]
+}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -336,8 +336,23 @@ class SingleElementTests(av.TestCase):
 
 
     def test_C3D8R_nonlinearShear12(self):
-        """ Nonlinear shear model, loading and unloading """
+        """ Nonlinear shear model, loading and unloading in 1-2 plane """
         self.runTest("test_C3D8R_nonlinearShear12")
+
+
+    def test_C3D8R_nonlinearShear12_loadReversal(self):
+        """ Nonlinear shear model, loading and unloading in 1-2 plane, including full load reversal """
+        self.runTest("test_C3D8R_nonlinearShear12_loadReversal")
+
+
+    def test_C3D8R_nonlinearShear13(self):
+        """ Nonlinear shear model, loading and unloading in 1-3 plane"""
+        self.runTest("test_C3D8R_nonlinearShear13")
+
+
+    def test_C3D8R_nonlinearShear13_loadReversal(self):
+        """ Nonlinear shear model, loading and unloading in 1-3 plane, including full load reversal"""
+        self.runTest("test_C3D8R_nonlinearShear13_loadReversal")
 
 
     def test_C3D8R_schapery12(self):

--- a/tests/test_runner_umat.py
+++ b/tests/test_runner_umat.py
@@ -51,6 +51,16 @@ class SingleElementTests(av.TestCase):
         self.runTest("test_C3D8R_UMAT_simpleShear12")
 
 
+    def test_C3D8R_UMAT_nonlinearShear12(self):
+        """ Nonlinear shear model, loading and unloading in 1-2 plane, Abaqus/Standard """
+        self.runTest("test_C3D8R_UMAT_nonlinearShear12")
+
+
+    def test_C3D8R_UMAT_nonlinearShear13(self):
+        """ Nonlinear shear model, loading and unloading in 1-3 plane, Abaqus/Standard """
+        self.runTest("test_C3D8R_UMAT_nonlinearShear13")
+
+
     def test_C3D8R_UMAT_fiberCompression_FKT(self):
         """ Fiber kinking model, Abaqus/Standard """
         self.runTest("test_C3D8R_UMAT_fiberCompression_FKT")


### PR DESCRIPTION
Added uncoupled Ramberg-Osgood shear nonlinearity in the 1-3 plane. This
capability compliments the existing shear nonlinearity capability
available in the 1-2 plane. Shear nonlinearity can be enabled in either
or both planes.

[CompDam_DGD_2dbac5e_2018-Jun-29.json.txt](https://github.com/nasa/CompDam_DGD/files/2155426/CompDam_DGD_2dbac5e_2018-Jun-29.json.txt)
