### PR TITLE
Clean analysis termination

### DIFF
--- a/for/DGD.for
+++ b/for/DGD.for
@@ -581,10 +581,10 @@ Contains
             If (sv%d2 >= damage_max) Then
               If (sv%alpha == -999) Then
                 Call writeDGDArgsToFile(m,p,sv,U,F,F_old,ndir,nshr,DT)
-                Call log%error('Invalid alpha. Check value for alpha in the initial conditions.')
+                Call log%terminate('Invalid alpha. Check value for alpha in the initial conditions.')
               End If
               If (p%terminate_on_no_convergence) Then
-                Call log%error('DGDEvolve failed to converge, terminating analysis.')
+                Call log%terminate('DGDEvolve failed to converge, terminating analysis.')
               Else
                 Call log%warn('Deleting failed element for which no solution could be found (DGDEvolve).')
                 sv%STATUS = 0
@@ -593,7 +593,8 @@ Contains
             End If
             ! ...raise an error and halt the subroutine.
             Call writeDGDArgsToFile(m,p,sv,U,F,F_old,ndir,nshr,DT)
-            Call log%error('No starting points produced a valid solution (DGDEvolve).')
+            Call log%terminate('No starting points produced a valid solution (DGDEvolve).')
+            Exit MatrixDamage
           End If
 
           cutbacks = 0
@@ -1250,7 +1251,7 @@ Contains
       If (err < tol_DGD .AND. MDet(Fkb) < p%compLimit) Then
         Call writeDGDArgsToFile(m,p,sv,U,F,F_old,ndir,nshr,DT)
         If (p%terminate_on_no_convergence) Then
-          Call log%error('Highly distorted element (DGDKinkband).')
+          Call log%terminate('Highly distorted element (DGDKinkband).')
         Else
           Call log%warn('Deleting highly distorted element (DGDKinkband).')
           sv%STATUS = 0
@@ -1282,7 +1283,7 @@ Contains
         Else
           Call writeDGDArgsToFile(m,p,sv,U,F,F_old,ndir,nshr,DT)
           If (p%terminate_on_no_convergence) Then
-            Call log%error('Equilibrium loop reached maximum number of iterations (DGDKinkband).')
+            Call log%terminate('Equilibrium loop reached maximum number of iterations (DGDKinkband).')
           Else
             Call log%warn('Deleting element for which equilibrium loop reached maximum number of iterations (DGDKinkband).')
             sv%STATUS = 0
@@ -1307,7 +1308,7 @@ Contains
         Else
           Call writeDGDArgsToFile(m,p,sv,U,F,F_old,ndir,nshr,DT)
           If (p%terminate_on_no_convergence) Then
-            Call log%error('Reached max cutback limit (DGDKinkband).')
+            Call log%terminate('Reached max cutback limit (DGDKinkband).')
           Else
             Call log%warn('Reached max cutback limit, deleting element (DGDKinkband).')
             sv%STATUS = 0

--- a/for/vexternaldb.for
+++ b/for/vexternaldb.for
@@ -22,28 +22,32 @@ Subroutine vexternaldb(lOp, i_Array, niArray, r_Array, nrArray)
   ! Locals
   Integer :: kStep                                     ! Current step number
   Integer :: kInc                                      ! Current increment number
+  Integer :: analysis_status
   Integer, parameter :: randomNumberCount = 10000
   Double Precision :: randomNumbers(randomNumberCount)
 
   ! Common
+  Common /analysis_termination/ analysis_status
   Common randomNumbers
   ! -------------------------------------------------------------------- !
-
 
   kStep = i_Array(i_int_kStep)
   kInc  = i_Array(i_int_kInc)
 
-
-  ! Note that you  can use the MPI communication between parallel Abaqus processes to gather
-  ! and scatter the data.
-
   ! Start of the analysis
   If (lOp == j_int_StartAnalysis) Then
 
-    ! User coding to set up the environment, open files, launch/connect to the external programs, etc.
+    ! Initialize common analysis_status variable
+    analysis_status = 1
 
     ! Initialize random numbers for fiber misalignment here
     Call RANDOM_NUMBER(randomNumbers)
+
+  ! End of the increment
+  Else If (lOp == j_int_EndIncrement) Then
+
+    ! If analysis_status has been changed, cleanly terminate the analysis
+    If (analysis_status == 0) i_Array(i_int_iStatus) = j_int_TerminateAnalysis
 
   End If
 

--- a/tests/test_C3D8R_error.inp
+++ b/tests/test_C3D8R_error.inp
@@ -1,0 +1,122 @@
+*Heading
+ Single element test for inducing a DGD convergence error
+**
+*Parameter
+ length = 0.2
+ displacement = 0.01
+ stepDuration = 0.1
+**
+ error_time_fraction = 0.45
+ error_time = stepDuration * error_time_fraction
+ error_time_end = error_time + stepDuration * 0.001
+**
+*Node, nset=AllNodes
+      1,            0.,            0.,            0.
+      2,      <length>,            0.,            0.
+      3,      <length>,      <length>,            0.
+      4,            0.,      <length>,            0.
+      5,            0.,            0.,      <length>
+      6,      <length>,            0.,      <length>
+      7,      <length>,      <length>,      <length>
+      8,            0.,      <length>,      <length>
+*Nset, nset=X+
+  2, 3, 6, 7
+*Nset, nset=X-
+  1, 4, 5, 8
+*Nset, nset=Y+
+  3, 4, 7, 8
+*Nset, nset=Y-
+  1, 2, 5, 6
+*Nset, nset=Z+
+  5, 6, 7, 8
+*Nset, nset=Z-
+  1, 2, 3, 4
+**
+*Element, type=C3D8R, elset=SingleElement
+  1, 1, 2, 3, 4, 5, 6, 7, 8
+**
+*Solid Section, elset=SingleElement, material=IM7-8552
+**
+*Material, name=IM7-8552
+*Density
+ 1.57e-09,
+*User material, constants=4
+ 100000, , <length>, , , , , ,
+*Depvar, delete=11
+19,
+1, CDM_d2
+2, CDM_Fb1
+3, CDM_Fb2
+4, CDM_Fb3
+5, CDM_B
+6, CDM_Lc1
+7, CDM_Lc2
+8, CDM_Lc3
+9, CDM_FIm
+10, CDM_alpha
+11, CDM_STATUS
+12, CDM_Plas12
+13, CDM_Inel12
+14, CDM_FIfT
+15, CDM_slide1
+16, CDM_slide2
+17, CDM_FIfC
+18, CDM_d1T
+19, CDM_d1C
+*Characteristic Length, definition=USER, components=3
+**
+*Initial Conditions, type=Solution
+SingleElement, 0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  -999,     1,  0.d0,  0.d0,  0.d0,
+0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Boundary
+1, 2, 3
+2, 1, 3
+3, 1, 1
+3, 3, 3
+4, 1, 1
+4, 3, 3
+5, 2, 2
+6, 1, 2
+7, 1, 1
+7, 3, 3
+8, 1, 1
+8, 3, 3
+**
+*Amplitude, name=Displace, definition=SMOOTH STEP
+0., 0., <stepDuration>, <displacement>
+*Amplitude, name=InsideOut, definition=TABULAR
+0., 0., <error_time>, 0., <error_time_end>, <length>, <stepDuration>, <length>
+**
+*Step, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+**
+*Fixed Mass Scaling, factor=5000.
+**
+*Boundary, amplitude=Displace
+Y+, 2, 2, -1.0
+*Boundary, amplitude=InsideOut
+1, 1, 1, 1.0
+1, 3, 3, 1.0
+2, 1, 1, -1.0
+2, 3, 3, 1.0
+5, 1, 1, 1.0
+5, 3, 3, -1.0
+6, 1, 1, -1.0
+6, 3, 3, -1.0
+**
+*Output, HISTORY, frequency=1
+*Energy Output
+ALLWK, ALLSE, ALLKE, ALLPD, ALLAE
+*Element Output, elset=SingleElement
+SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV11, SDV15,
+SDV16
+**
+*Output, FIELD, number interval=10
+*Element Output
+SDV, S, LE
+*Node Output
+U, RF
+**
+*END STEP

--- a/tests/test_C3D8R_error_expected.py
+++ b/tests/test_C3D8R_error_expected.py
@@ -1,0 +1,15 @@
+parameters = {
+	"results": [
+        {
+            "type": "max",
+            "identifier":
+                {
+                    "symbol": "SDV_CDM_d2",
+                    "elset": "SINGLEELEMENT",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 1.0,
+            "tolerance": 0.0
+        }
+	]
+}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -396,6 +396,11 @@ class SingleElementTests(av.TestCase):
 
     # -----------------------------------------------------------------------------------------
     # Test methods
+    def test_C3D8R_error(self):
+        """ Intentionally cause a DGD convergence error """
+        self.runTest("test_C3D8R_error")
+
+
     def test_C3D8R_matrixTension(self):
         """ Simple tension in the matrix direction, with damage """
         self.runTest("test_C3D8R_matrixTension")


### PR DESCRIPTION
- Use vexternaldb to cleanly terminate analyses at the end of an 
increment.
- New logger function for clean termination (log%terminate). log%error 
is still used for immediate termination of an analysis. log%error should 
still be used for dealing with input errors and numerical errors. 
Convergence errors should usually be able to use log%terminate without 
issue.
- Added a test which causes a DGD convergence issue in a single element. 
With the other changes in this commit, an additional output frame is 
generated. Previously, no data from the last model state would be added 
to the ODB file.