### PR TITLE
Update cohesive fatigue law and refactor static cohesive equations

### DIFF
--- a/examples/CompDam.parameters
+++ b/examples/CompDam.parameters
@@ -34,8 +34,8 @@ cycles_per_increment_min = 1.d-5 // Default value: 1.d-5
 cycles_per_increment_mod = 0.1d0 // Default value: 0.1d0
 
 // thresholds for fatigue damage progression per solution increment in terms of percent fracture toughness, Double precision
-fatigue_damage_min_threshold = 5.d-6 // Default value: 5.d-6
-fatigue_damage_max_threshold = 1.d-4 // Default value: 1.d-4
+fatigue_damage_min_threshold = 5.d-5 // Default value: 5.d-6
+fatigue_damage_max_threshold = 1.d-3 // Default value: 1.d-4
 
 
 // penalty stiffness multiplier, K/(E/thickness) = penStiffMult, Double precision

--- a/examples/test_DCB_fatigue.inp
+++ b/examples/test_DCB_fatigue.inp
@@ -20,18 +20,28 @@ HL = XL + crackLength     # Maximum crack length at end of analysis
 ********************************************************************************
 ** Cohesive material parameters
 ********************************************************************************
-** Cohesive law
-YT = 80.1  # Mode I strength
-SL = 97.6  # Mode II strength
-K1 = 2.E5  # Cohesive penalty stiffness (mode I)
-GIc = 0.240  # Mode I fracture toughness
-GIIc = 0.739  # mode II fracture toughness
-**
-YC = 199.8  # compressive matrix strength
-BK_eta = 2.1  # Benzeggagh-Kenane mode mixity exponent
-alpha0 = 0.925  # 2--3 plane crack angle under pure matrix compression [radians]
-**
 density = 1.57e-09  # Density for carbon/epoxy materials
+YC = 199.8  # compressive matrix strength
+alpha0 = 0.925  # 2--3 plane crack angle under pure matrix compression [radians]
+** Initiation cohesive law
+YT_init = 80.0  # Mode I strength
+SL_init = 99.0  # Mode II strength
+K1_init = 2.E5  # Cohesive penalty stiffness (mode I)
+GIc_init = 0.214  # Mode I fracture toughness
+GIIc_init = 0.59  # mode II fracture toughness
+BK_eta_init = 2.1  # Benzeggagh-Kenane mode mixity exponent
+**
+density_init = density/2.0  # Density for carbon/epoxy materials
+********************************************************************************
+** Bridging cohesive law
+YT_brdg = 0.8  # Mode I strength
+SL_brdg = 1.0  # Mode II strength
+K1_brdg = K1_init * YT_brdg / YT_init  # Cohesive penalty stiffness (mode I)
+GIc_brdg = 0.140  # Mode I fracture toughness
+GIIc_brdg = 0.193  # mode II fracture toughness
+BK_eta_brdg = 3.0
+**
+density_brdg = density/2.0  # Density for carbon/epoxy materials
 ********************************************************************************
 ** Loading parameters
 ********************************************************************************
@@ -45,10 +55,10 @@ time_2 = 0.15  # time duration for step 2 (fatigue)
 ** Meshing Parameters
 ********************************************************************************
 NEW=  6    # Number of elements in width direction (y-dir)
-NET=  3    # Number of elements in sublamina (z-dir)
+NET=  6    # Number of elements in sublamina (z-dir)
 NEA= 24    # Number of elements in length direction before Crack, coarse (x-dir)
 NEB= 20    # Number of elements in length direction before Crack, fine (x-dir)
-NEC=200    # Number of elements in length direction after Crack (x-dir)
+NEC=250    # Number of elements in length direction after Crack (x-dir)
 NED= 20    # Number of elements in length direction after cracking (x-dir)
 **
 top_arm_element_thickness = TTL/NET
@@ -64,8 +74,8 @@ bot_arm_element_thickness = TBL/NET
 ********************************************************************************
 *Material, name=cohesive
 *Density
-<density>,
-*Depvar
+<density_init>,
+*Depvar, delete=11
 19,
 1, COH_dmg
 2, COH_delta_s1
@@ -75,14 +85,36 @@ bot_arm_element_thickness = TBL/NET
 9, COH_FI
 11, COH_STATUS
 *User Material, constants=40
-200000, , 0., , , , , ,
-, , , , , <YT>, <SL>, <GIc>,
-<GIIc>, <BK_eta>, <YC>, <alpha0>, <K1>, , , ,
+200000, , 0., , 1.d7, 0.2, 0.95, 0.0,
+, , , , , <YT_init>, <SL_init>, <GIc_init>,
+<GIIc_init>, <BK_eta_init>, <YC>, <alpha0>, <K1_init>, , , ,
+, , , , , , , ,
+, , , , , , , 0.0
+*Material, name=cohesive_bridge
+*Density
+<density_brdg>,
+*Depvar, delete=11
+19,
+1, COH_dmg
+2, COH_delta_s1
+3, COH_delta_n
+4, COH_delta_s2
+5, COH_B
+9, COH_FI
+11, COH_STATUS
+*User Material, constants=40
+200000, , 0., , 1.d7, 0.2, 0.95, 0.0,
+, , , , , <YT_brdg>, <SL_brdg>, <GIc_brdg>,
+<GIIc_brdg>, <BK_eta_brdg>, <YC>, <alpha0>, <K1_brdg>, , , ,
 , , , , , , , ,
 , , , , , , , 0.0
 **
 *Initial Conditions, type=SOLUTION
 COH, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+0.0, 0.0, 0, 1, 0.0, 0.0, 0.0, 0.0,
+0.0, 0.0, 0.0, 0.0
+*Initial Conditions, type=SOLUTION
+COH_bridge, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 0.0, 0.0, 0, 1, 0.0, 0.0, 0.0, 0.0,
 0.0, 0.0, 0.0, 0.0
 ********************************************************************************
@@ -321,6 +353,7 @@ OPEN_TOP_A, OPEN_TOP_B, MIDDLE_TOP, END_TOP,
  <COH_B>, <NED>, 1 , 1 , <NEW>, <NNL>, <NEL>, 1, 50000, 50000
 *Elset, elset=COH
  FRONT_COH, BACK_COH
+*Elcopy, old set=COH, new set=COH_bridge, shift nodes=0, element shift=1000000
 ********************************************************************************
 ** Section definitions
 ********************************************************************************
@@ -334,6 +367,8 @@ OPEN_TOP_A, OPEN_TOP_B, MIDDLE_TOP, END_TOP,
 <top_arm_element_thickness>, 5
 **
 *Cohesive section, elset=COH, response=TRACTION SEPARATION, material=cohesive, thickness=SPECIFIED
+1.0
+*Cohesive section, elset=COH_bridge, response=TRACTION SEPARATION, material=cohesive_bridge, thickness=SPECIFIED
 1.0
 ********************************************************************************
 ** Boundary conditions and constraints
@@ -382,6 +417,8 @@ U,
 S, EMSF
 *Element Output, elset=COH
 SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV11,
+*Element Output, elset=COH_bridge
+SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV11,
 **
 *End Step
 ********************************************************************************
@@ -398,6 +435,10 @@ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV11,
 *Output, history, freq=1
 *Energy Output
 ALLSE, ALLPD, ALLKE, ALLVD, ALLWK, ALLMW
+*Energy Output, elset=COH
+ALLPD
+*Energy Output, elset=COH_bridge
+ALLPD
 *Node Output, nset=T_Node
 RF3, U3
 **
@@ -407,6 +448,8 @@ U,
 *Element Output
 S,
 *Element Output, elset=COH
+SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV11,
+*Element Output, elset=COH_bridge
 SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV11,
 **
 *End Step

--- a/examples/test_DCB_fatigue_expected.py
+++ b/examples/test_DCB_fatigue_expected.py
@@ -11,13 +11,13 @@ parameters = {
                 "position": "Node 9999998"
             },
             "referenceValue": staticLoad,
-            "tolerance": staticLoad * 0.005
+            "tolerance": staticLoad * 0.01
         },
         {
             "type": "max",
-            "identifier": "Plastic dissipation: ALLPD for Whole Model",
-            "referenceValue": 1.63141,  # Unrecoverable energy dissipation from fracture * fracture area: GYT * delta_a * width
-            "tolerance": 0.01
+            "identifier": "Plastic dissipation: ALLPD in ELSET COH",
+            "referenceValue": 1.605,  # Unrecoverable energy dissipation from fracture * fracture area: GIc_init * delta_a * width
+            "tolerance": 0.05
         },
     ]
 }

--- a/for/CompDam_DGD.for
+++ b/for/CompDam_DGD.for
@@ -382,8 +382,8 @@ Subroutine CompDam(  &
           Call log%error("Found Lc2 = 0. Perhaps *Characteristic Length is missing from the input deck?")
         Else If (sv%Lc(3) .EQ. zero) Then
           Call log%error("Found Lc3 = 0. Perhaps *Characteristic Length is missing from the input deck?")
-        Else If (sv%Lc(2) > sv%Lc(1)*10.d0 .OR. sv%Lc(2) < sv%Lc(1)/10.d0) Then
-          Call log%warn("Found Lc = [" // trim(str(sv%Lc(1))) //','// trim(str(sv%Lc(2))) //','// trim(str(sv%Lc(3))) // "]; perhaps *Characteristic Length is missing from the input deck?")
+        ! Else If (sv%Lc(2) > sv%Lc(1)*10.d0 .OR. sv%Lc(2) < sv%Lc(1)/10.d0) Then
+        !   Call log%warn("Found Lc = [" // trim(str(sv%Lc(1))) //','// trim(str(sv%Lc(2))) //','// trim(str(sv%Lc(3))) // "]; perhaps *Characteristic Length is missing from the input deck?")
         End If
       End If
 

--- a/for/CompDam_DGD.for
+++ b/for/CompDam_DGD.for
@@ -296,14 +296,20 @@ Subroutine CompDam(  &
 
     ! Determine current cohesive displacement-jump
     !  Assumes a constitutive thickness equal to one.
-    delta(1) = sv%Fb1 + two*strainInc(km,3)  ! First shear direction (1--3)
-    delta(2) = sv%Fb2 + strainInc(km,1)      ! Normal direction (3--3)
-    delta(3) = sv%Fb3 + two*strainInc(km,2)  ! Second shear direction (2--3)
+    If (nshr == 2) Then
+      delta(1) = sv%Fb1 + two*strainInc(km,3)  ! Longitudinal shear direction (1--3)
+      delta(2) = sv%Fb2 + strainInc(km,1)      ! Normal direction (3--3)
+      delta(3) = sv%Fb3 + two*strainInc(km,2)  ! Transverse shear direction (2--3)
+    Else
+      delta(1) = sv%Fb1 + two*strainInc(km,2)  ! Shear direction (1--2)
+      delta(2) = sv%Fb2 + strainInc(km,1)      ! Normal normal (2--2)
+      delta(3) = zero
+    End If
 
     ! Store current cohesive displacement-jump
-    sv%Fb1 = delta(1)  ! First shear direction
-    sv%Fb2 = delta(2)  ! Normal direction
-    sv%Fb3 = delta(3)  ! Second shear direction
+    sv%Fb1 = delta(1)  ! Longitudinal shear displacement-jump
+    sv%Fb2 = delta(2)  ! Normal displacement-jump
+    sv%Fb3 = delta(3)  ! Transverse shear displacement-jump
 
     If (totalTime == 0) Then  ! Avoids calculating damage during the packager and the first solution increment
       Call cohesive_damage(m, p, delta, Pen, delta(2), sv%B, sv%FIm)
@@ -325,9 +331,13 @@ Subroutine CompDam(  &
     If (sv%d2 >= one) sv%STATUS = 0
 
     ! Update stress values
-    stressNew(km,3) = T_coh(1)  ! First shear direction (1--3)
-    stressNew(km,1) = T_coh(2)  ! Normal direction (3--3)
-    stressNew(km,2) = T_coh(3)  ! Second shear direction (2--3)
+    stressNew(km,1) = T_coh(2)  ! Normal stress
+    If (nshr == 2) Then  ! 3-D
+      stressNew(km,3) = T_coh(1)  ! Longitudinal shear stress (1--3)
+      stressNew(km,2) = T_coh(3)  ! Transverse shear stress (2--3)
+    Else  ! 2-D
+      stressNew(km,2) = T_coh(1)  ! Shear stress
+    End If
 
     ! Update internal and inelastic energy terms
     enerInternNew(km) = DOT_PRODUCT(T_coh, delta)/two

--- a/for/cohesive.for
+++ b/for/cohesive.for
@@ -26,7 +26,6 @@ Contains
     Double Precision :: del0n, del0s                                         ! Initiation displacements for pure Mode I and Mode II
     Double Precision :: delfn, delfs                                         ! Final displacements for pure Mode I and Mode II
     Double Precision :: d0, df                                               ! Initiation and final displacements for current mode-mixity ratio
-    Double Precision :: del0nB, del0sB, delfnB, delfsB                       ! Temporary, used to calculate d0 and df
     Double Precision :: damage_max                                           ! Maximum value for damage variable
     Double Precision :: beta                                                 ! Placeholder (temp.) variables for Mode-mixity
     Double Precision :: KS                                                   ! Shear penalty stiffness
@@ -109,9 +108,7 @@ Contains
       B = zero
       d0 = del0n
     Else
-      del0nB = SQRT(((one - B**m%eta_BK)*del0n*del0n + KS/Pen(2)*B**m%eta_BK*del0s*del0s)*(one - B))
-      del0sB = SQRT(beta/(one - beta))*del0nB
-      d0 = SQRT(del0nB*del0nB + del0sB*del0sB)
+      d0 = SQRT( (del0n**2 + (del0s**2*KS/Pen(2) - del0n**2)*B**m%eta_BK)*(one + B*(Pen(2)/KS - one)) )
     End If
 
     FI = MIN(one, del/d0)
@@ -129,9 +126,7 @@ Contains
       Else If (B <= mode_mix_limit) Then
         df = delfn
       Else
-        delfnB = ((one - B**m%eta_BK)*del0n*delfn + KS/Pen(2)*B**m%eta_BK*del0s*delfs)*(one - B)/del0nB
-        delfsB = SQRT(beta/(one - beta))*delfnB
-        df = SQRT(delfnB*delfnB + delfsB*delfsB)
+        df = (del0n*delfn + (del0s*delfs*KS/Pen(2) - del0n*delfn)*B**m%eta_BK)*(one + B*(Pen(2)/KS - one))/d0
       End If
 
       ! Determine the new damage state

--- a/for/cohesive.for
+++ b/for/cohesive.for
@@ -152,8 +152,7 @@ Contains
         R_old = damage_old*d0/((one - damage_old)*df + damage_old*d0)  ! Transform old damage to R form
         R_max = damage_max*d0/((one - damage_max)*df + damage_max*d0)  ! Transform damage_max to R form
 
-        ! Relative endurance at R=-1, corrected for mode mixity B, based on:
-        !   Juvinall, R. C., and Marshek, K. M., Fundamentals of Machine Component Design, Wiley, New York, NY, 2000.
+        ! Relative endurance at R=-1, corrected for mode mixity B
         epsilon_mixed = m%fatigue_epsilon*(one - B*0.42d0)
         ! Relative endurance for all R ratios and mode mixities
         endurance_relative = two*epsilon_mixed/(epsilon_mixed + one + p%fatigue_R_ratio*(epsilon_mixed - one))

--- a/for/cohesive.for
+++ b/for/cohesive.for
@@ -161,7 +161,7 @@ Contains
         fatigue_beta = -seven*m%fatigue_eta/log10(endurance_relative)  ! Equation 23 in CF20 technical paper
         fatigue_p_cf20 = fatigue_beta + m%fatigue_p_mod
 
-        lambda_relative = min(del/((one - R_old)*d0 + R_old*df), one)  ! Relative displacement jump
+        lambda_relative = del/((one - R_old)*d0 + R_old*df)  ! Relative displacement jump
         If (lambda_relative < endurance_relative) lambda_relative = zero  ! threshold of propagation
 
         R_fatigue_inc = (one - R_old)**(fatigue_beta - fatigue_p_cf20) * (lambda_relative/endurance_relative)**fatigue_beta * &

--- a/for/matProp.for
+++ b/for/matProp.for
@@ -21,14 +21,10 @@ Module matProp_Mod
     Double Precision :: XT, fXT, GXT, fGXT                               ! Opt. Longitudinal tensile damage (max strain failure criterion, bilinear softening)
     Double Precision :: XC, fXC, GXC, fGXC                               ! Opt. Longitudinal compressive damage (max strain failure criterion, bilinear softening)
     Double Precision :: w_kb                                             ! Opt. LaRC15 kink band model (Also requires XC, shear nonlinearity).
-    Double Precision :: cl                                           ! Opt. fiber nonlinearity (defaults to zero, which is no fiber nonlinearity)
+    Double Precision :: cl                                               ! Opt. fiber nonlinearity (defaults to zero, which is no fiber nonlinearity)
     Double Precision :: mu                                               ! Opt. Friction. Defaults to zero
-    Double Precision :: es(4), gs(4)
-    Double Precision :: schaefer_a6
-    Double Precision :: schaefer_b2
-    Double Precision :: schaefer_n
-    Double Precision :: schaefer_A                                       ! Specified parameters for schaefer theory
-    Double Precision :: fatigue_gamma, epsilon, brittleness, fatigue_p   ! Opt. CF20 fatigue properties
+    Double Precision :: es(4), gs(4)                                     ! Opt. Schapery theory inputs
+    Double Precision :: schaefer_a6, schaefer_b2, schaefer_n, schaefer_A  ! Opt. Schaefer nonlinearity model inputs
     Double Precision :: fatigue_gamma, fatigue_epsilon, fatigue_eta, fatigue_p_mod  ! Opt. CF20 fatigue properties
 
     ! min and max values for acceptable range
@@ -373,6 +369,7 @@ Contains
             Call verifyAndSaveProperty_str(trim(key), value, m%schapery_min, m%schapery_max, m%gs(3), m%gs_def(3))
           Case ('gs3')
             Call verifyAndSaveProperty_str(trim(key), value, m%schapery_min, m%schapery_max, m%gs(4), m%gs_def(4))
+
           ! Schaefer Theory
           Case ('schaefer_a6')
             Call verifyAndSaveProperty_str(trim(key), value, m%schaefer_min, m%schaefer_max, m%schaefer_a6, m%schaefer_a6_def)
@@ -382,6 +379,7 @@ Contains
             Call verifyAndSaveProperty_str(trim(key), value, m%schaefer_min, m%schaefer_max, m%schaefer_n, m%schaefer_n_def)
           Case ('schaefer_A')
             Call verifyAndSaveProperty_str(trim(key), value, m%schaefer_min, m%schaefer_max, m%schaefer_A, m%schaefer_A_def)
+
           Case Default
             Call log%error("loadMatProps: Property not recognized: " // trim(key))
         End Select

--- a/for/matProp.for
+++ b/for/matProp.for
@@ -886,22 +886,28 @@ Contains
         m%v13 = m%v12
         m%G23 = m%E2/two/(one + m%v23)
       End If
-    Else
+
+    Else If (m%cohesive) Then  ! Check if cohesive element properties have been specified
       ! Check for cohesive stiffness material properties
       If (.NOT. m%E3_def) Call log%error('PROPERTY ERROR: Cohesive material laws require a definition for E3.')
       ! Check for cohesive strength material properties
       If (.NOT. m%YT_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for YT.')
-      If (.NOT. m%SL_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for SL_def.')
-      If (.NOT. m%YC_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for YC.')
-      If (.NOT. m%alpha0_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for alpha0.')
+      If (.NOT. m%SL_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for SL.')
+      If (m%YC_def .AND. m%alpha0_def) Then
+        ! Compute these properties for the transverse shear strength
+        m%etaL = -m%SL*COS(two*m%alpha0)/(m%YC*COS(m%alpha0)*COS(m%alpha0))
+        m%etaT = -one/TAN(two*m%alpha0)
+        m%ST   = m%YC*COS(m%alpha0)*(SIN(m%alpha0) + COS(m%alpha0)/TAN(two*m%alpha0))
+      Else
+        Call log%info('PROPERTY: YC and/or alpha0 not defined. Assuming that S_T = S_L.')
+        m%etaL = zero
+        m%etaT = zero
+        m%ST   = m%SL
+      End If
       ! Check for cohesive fracture toughness material properties
       If (.NOT. m%GYT_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for GYT.')
       If (.NOT. m%GSL_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for GSL.')
       If (.NOT. m%eta_BK_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for eta_BK.')
-      ! Compute these properties for the transverse shear strength
-      m%etaL = -m%SL*COS(two*m%alpha0)/(m%YC*COS(m%alpha0)*COS(m%alpha0))
-      m%etaT = -one/TAN(two*m%alpha0)
-      m%ST   = m%YC*COS(m%alpha0)*(SIN(m%alpha0) + COS(m%alpha0)/TAN(two*m%alpha0))
 
       Call log%info('PROPERTY: All required cohesive element peroperties are defined.')
     End IF
@@ -909,30 +915,12 @@ Contains
     ! Check if matrix damage properties have been specified
     If (m%matrixDam) Then
       If (.NOT. m%YT_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for YT.')
-      If (.NOT. m%SL_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for SL_def.')
+      If (.NOT. m%SL_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for SL.')
       If (.NOT. m%GYT_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for GYT.')
       If (.NOT. m%GSL_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for GSL.')
       If (.NOT. m%eta_BK_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for eta_BK.')
       If (.NOT. m%YC_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for YC.')
       If (.NOT. m%alpha0_def) Call log%error('PROPERTY ERROR: Some matrix damage properties are missing. Must define a value for alpha0.')
-      m%etaL = -m%SL*COS(two*m%alpha0)/(m%YC*COS(m%alpha0)*COS(m%alpha0))
-      m%etaT = -one/TAN(two*m%alpha0)
-      m%ST   = m%YC*COS(m%alpha0)*(SIN(m%alpha0) + COS(m%alpha0)/TAN(two*m%alpha0))
-
-      Call log%info('PROPERTY: Matrix damage is enabled')
-    Else
-      Call log%info('PROPERTY: Matrix damage is disabled')
-    End If
-
-    ! Check if cohesive element properties have been specified
-    If (m%cohesive) Then
-      If (.NOT. m%YT_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for YT.')
-      If (.NOT. m%SL_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for SL_def.')
-      If (.NOT. m%GYT_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for GYT.')
-      If (.NOT. m%GSL_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for GSL.')
-      If (.NOT. m%eta_BK_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for eta_BK.')
-      If (.NOT. m%YC_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for YC.')
-      If (.NOT. m%alpha0_def) Call log%error('PROPERTY ERROR: Some cohesive element properties are missing. Must define a value for alpha0.')
       m%etaL = -m%SL*COS(two*m%alpha0)/(m%YC*COS(m%alpha0)*COS(m%alpha0))
       m%etaT = -one/TAN(two*m%alpha0)
       m%ST   = m%YC*COS(m%alpha0)*(SIN(m%alpha0) + COS(m%alpha0)/TAN(two*m%alpha0))

--- a/for/parameters.for
+++ b/for/parameters.for
@@ -414,17 +414,17 @@ Contains
     p%fatigue_R_ratio_min = -one
     p%fatigue_R_ratio_max = one
 
-    p%cycles_per_increment_init_min = 1.d-6
-    p%cycles_per_increment_init_max = 1.d+6
+    p%cycles_per_increment_init_min = Tiny(zero)
+    p%cycles_per_increment_init_max = Huge(zero)
 
     p%cycles_per_increment_mod_min = Tiny(zero)
-    p%cycles_per_increment_mod_max = 9.d0  ! corresponds to changing cycles_per_increment by a factor of 10
+    p%cycles_per_increment_mod_max = Huge(zero)
 
-    p%cycles_per_increment_max_min = one
+    p%cycles_per_increment_max_min = Tiny(zero)
     p%cycles_per_increment_max_max = Huge(zero)
 
     p%cycles_per_increment_min_min = Tiny(zero)
-    p%cycles_per_increment_min_max = one
+    p%cycles_per_increment_min_max = Huge(zero)
 
     p%fatigue_damage_min_threshold_min = Tiny(zero)
     p%fatigue_damage_min_threshold_max = one

--- a/for/parameters.for
+++ b/for/parameters.for
@@ -268,28 +268,28 @@ Contains
             Call verifyAndSaveProperty_dbl(trim(key), value, p%fkt_init_misalignment_polar_scale_min, p%fkt_init_misalignment_polar_scale_max, p%fkt_init_misalignment_polar_scale)
 
           Case ('fatigue_R_ratio')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%fatigue_R_ratio_min, p%fatigue_R_ratio_max, p%fatigue_R_ratio)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%fatigue_R_ratio_min, p%fatigue_R_ratio_max, p%fatigue_R_ratio, .FALSE.)
 
           Case ('cycles_per_increment_init')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_init_min, p%cycles_per_increment_init_max, p%cycles_per_increment_init)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_init_min, p%cycles_per_increment_init_max, p%cycles_per_increment_init, .FALSE.)
 
           Case ('cycles_per_increment_mod')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_mod_min, p%cycles_per_increment_mod_max, p%cycles_per_increment_mod)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_mod_min, p%cycles_per_increment_mod_max, p%cycles_per_increment_mod, .FALSE.)
 
           Case ('cycles_per_increment_max')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_max_min, p%cycles_per_increment_max_max, p%cycles_per_increment_max)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_max_min, p%cycles_per_increment_max_max, p%cycles_per_increment_max, .FALSE.)
 
           Case ('cycles_per_increment_min')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_min_min, p%cycles_per_increment_min_max, p%cycles_per_increment_min)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%cycles_per_increment_min_min, p%cycles_per_increment_min_max, p%cycles_per_increment_min, .FALSE.)
 
           Case ('fatigue_damage_min_threshold')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%fatigue_damage_min_threshold_min, p%fatigue_damage_min_threshold_max, p%fatigue_damage_min_threshold)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%fatigue_damage_min_threshold_min, p%fatigue_damage_min_threshold_max, p%fatigue_damage_min_threshold, .FALSE.)
 
           Case ('fatigue_damage_max_threshold')
-            Call verifyAndSaveProperty_dbl(trim(key), value, p%fatigue_damage_max_threshold_min, p%fatigue_damage_max_threshold_max, p%fatigue_damage_max_threshold)
+            Call verifyAndSaveProperty_dbl(trim(key), value, p%fatigue_damage_max_threshold_min, p%fatigue_damage_max_threshold_max, p%fatigue_damage_max_threshold, .FALSE.)
 
           Case ('fatigue_step')
-            Call verifyAndSaveProperty_int(trim(key), value, p%fatigue_step_min, p%fatigue_step_max, p%fatigue_step)
+            Call verifyAndSaveProperty_int(trim(key), value, p%fatigue_step_min, p%fatigue_step_max, p%fatigue_step, .FALSE.)
 
           Case Default
             Call log%error("loadParameters: Parameter not recognized: " // trim(key))
@@ -439,7 +439,7 @@ Contains
   End Subroutine initializeParameters
 
 
-  Subroutine verifyAndSaveProperty_dbl(key, value, min, max, saveTo)
+  Subroutine verifyAndSaveProperty_dbl(key, value, min, max, saveTo, nondefaultWarn_arg)
     ! Checks if the value is within the specified bounds. Prints an error message
     ! which kills the analysis if a value is out of bounds.
 
@@ -449,10 +449,18 @@ Contains
     Character(len=*), intent(IN) :: key, value
     Double Precision, intent(IN) :: min, max
     Double Precision, intent(INOUT) :: saveTo
+    Logical, intent(IN), optional :: nondefaultWarn_arg
 
     ! Locals
     Double Precision :: valueDbl
+    Logical :: nondefaultWarn
     ! -------------------------------------------------------------------- !
+
+    If (Present(nondefaultWarn_arg)) Then
+      nondefaultWarn = nondefaultWarn_arg
+    Else
+      nondefaultWarn = .TRUE.
+    End If
 
     ! Convert to double
     Read(value,*) valueDbl
@@ -467,7 +475,7 @@ Contains
     End If
 
     ! Check for non-default
-    If (valueDbl .NE. saveTo) Then
+    If ((valueDbl .NE. saveTo) .AND. nondefaultWarn) Then
       Call log%warn("Non-default parameter: " // trim(key) // " = " // trim(str(valueDbl)) // ", default = " // trim(str(saveTo)))
     End If
 
@@ -477,7 +485,7 @@ Contains
     Return
   End Subroutine verifyAndSaveProperty_dbl
 
-  Subroutine verifyAndSaveProperty_int(key, value, min, max, saveTo)
+  Subroutine verifyAndSaveProperty_int(key, value, min, max, saveTo, nondefaultWarn_arg)
     ! Checks if the value is within the specified bounds. Prints an error message
     ! which kills the analysis if a value is out of bounds.
 
@@ -487,10 +495,18 @@ Contains
     Character(len=*), intent(IN) :: key, value
     Integer, intent(IN) :: min, max
     Integer, intent(INOUT) :: saveTo
+    Logical, intent(IN), optional :: nondefaultWarn_arg
 
     ! Locals
     Integer :: valueInt
+    Logical :: nondefaultWarn
     ! -------------------------------------------------------------------- !
+
+    If (Present(nondefaultWarn_arg)) Then
+      nondefaultWarn = nondefaultWarn_arg
+    Else
+      nondefaultWarn = .TRUE.
+    End If
 
     ! Convert to integer
     Read(value,*) valueInt
@@ -505,7 +521,7 @@ Contains
     End If
 
     ! Check for non-default
-    If (valueInt .NE. saveTo) Then
+    If ((valueInt .NE. saveTo) .AND. nondefaultWarn) Then
       Call log%warn("Non-default parameter: " // trim(key) // " = " // trim(str(valueInt)) // ", default = " // trim(str(saveTo)))
     End If
 
@@ -515,7 +531,7 @@ Contains
     Return
   End Subroutine verifyAndSaveProperty_int
 
-  Subroutine verifyAndSaveProperty_logical(key, value, saveTo)
+  Subroutine verifyAndSaveProperty_logical(key, value, saveTo, nondefaultWarn_arg)
     ! Checks if the value is true or false. Prints an error message
     ! which kills the analysis if a value is not true or false.
 
@@ -524,10 +540,18 @@ Contains
     !Arguments
     Character(len=*), intent(IN) :: key, value
     Logical, intent(INOUT) :: saveTo
+    Logical, intent(IN), optional :: nondefaultWarn_arg
 
     ! Locals
     Logical :: valueLogical
+    Logical :: nondefaultWarn
     ! -------------------------------------------------------------------- !
+
+    If (Present(nondefaultWarn_arg)) Then
+      nondefaultWarn = nondefaultWarn_arg
+    Else
+      nondefaultWarn = .TRUE.
+    End If
 
     ! Check for T or F
     If ((value /= '.TRUE.') .AND. (value /= '.FALSE.')) Then
@@ -538,7 +562,7 @@ Contains
     Read(value,*) valueLogical
 
     ! Check for non-default
-    If (valueLogical .NE. saveTo) Then
+    If ((valueLogical .NE. saveTo) .AND. nondefaultWarn) Then
       Call log%warn("Non-default parameter: " // trim(key) // " = " // trim(str(valueLogical)))
     End If
 

--- a/readme.md
+++ b/readme.md
@@ -709,8 +709,8 @@ We invite your contributions to CompDam_DGD! Please submit contributions (includ
 If you use CompDam, please cite using the following BibTex entry:
 
     @misc{CompDam,
-    title={CompDam - Deformation Gradient Decomposition (DGD), v2.5.0},
-    author={Leone, F. A., Bergan, A. C., D\'avila, C. G. },
-    note={https://github.com/nasa/CompDam_DGD},
+    title={Comp{D}am - {D}eformation {G}radient {D}ecomposition ({DGD}), v2.5.0},
+    author={Frank A. Leone and Andrew C. Bergan and Carlos G. D\'{a}vila},
+    note={https://github.com/nasa/CompDam\_DGD},
     year={2019}
     }

--- a/tests/test_COH2D4_normal.inp
+++ b/tests/test_COH2D4_normal.inp
@@ -1,0 +1,92 @@
+*Heading
+ Single cohesive element test for mode I response
+**
+*Parameter
+ length = 0.2
+ thickness = 0.0
+ displacement = 0.01
+ stepDuration = 0.1
+**
+*Node, nset=Nodes
+      1,            0.,            0.
+      2,      <length>,            0.
+      3,      <length>,      <thickness>
+      4,            0.,      <thickness>
+*Nset, nset=X+
+  2, 3
+*Nset, nset=X-
+  1, 4
+*Nset, nset=Y+
+  3, 4
+*Nset, nset=Y-
+  1, 2
+**
+*Element, type=COH2D4, elset=COHESIVE
+  1, 1, 2, 3, 4
+**
+*Cohesive Section, elset=COHESIVE, material=IM7-8552, response=TRACTION SEPARATION, thickness=SPECIFIED
+ 1.0,
+**
+*Material, name=IM7-8552
+*Density
+ 1.57e-09,
+*User material, constants=40
+** feature flags, ,   thickness, 4, 5, 6, 7, 8
+          200000, , <thickness>,  ,  ,  ,  ,  ,
+**  9         10        11        12        13        14        15        16
+**  E1,       E2,       G12,      nu12,     nu23,     YT,       SL        GYT
+      ,         ,          ,          ,         ,     62.3,     92.30,    0.277,
+**  17        18        19        20        21        22        23        24
+**  GSL,      eta_BK,   YC,       alpha0    E3,       G13,      G23,      nu13,
+    0.788,    1.634,    199.8,    0.925,    1.d6,        ,         ,          ,
+**  25        26        27        28        29        30        31        32
+**  alpha11,  alpha22,  alpha_PL, n_PL,     XT,       fXT,      GXT,      fGXT,
+           ,         ,          ,     ,       ,          ,         ,          ,
+**  33        34        35        36        37        38        39        40
+**  XC,       fXC,      GXC,      fGXC,     phi_ff,   w_kb,     phi0,     mu
+      ,          ,         ,          ,           ,       ,         ,     0.3
+*Depvar
+  19,
+  1, COH_dmg
+  2, COH_delta_s1
+  3, COH_delta_n
+  4, COH_delta_s2
+  5, COH_B
+  9, COH_FI
+ 15, COH_slide1
+ 16, COH_slide2
+** *Characteristic Length, definition=USER, components=2
+**
+*Initial Conditions, Type=Solution
+ COHESIVE,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Boundary
+  Y+, 1, 1, 0
+  Y-, 1, 2, 0
+**
+*Amplitude, name=LoadUp, definition=SMOOTH STEP
+ 0., 0., <stepDuration>, 1.
+**
+*Step, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+*Fixed Mass Scaling, factor=5000.
+**
+*Boundary, AMPLITUDE=LoadUp
+ Y+, 2, 2, <displacement>
+**
+*Output, FIELD
+*Element Output
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+*Node Output
+ U, RF
+*Output, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE, ALLPD
+*Node Output, NSET=Y+
+ U, RF
+*Element Output, ELSET=COHESIVE
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+**
+*End Step

--- a/tests/test_COH2D4_normal_expected.py
+++ b/tests/test_COH2D4_normal_expected.py
@@ -1,0 +1,57 @@
+parameters = {
+	"results": [
+		{
+            "type": "max",
+            "identifier":
+                {
+                    "symbol": "S22",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 62.3, # YT
+            "tolerance": 0.0623
+        },
+        {
+            "type": "disp_at_zero_y",
+            "step": "Step-1",
+            "identifier": [
+                { # x
+                    "symbol": "U2",
+                    "nset": "Y+",
+                    "position": "Node 4"
+                },
+                { # y
+                    "symbol": "S22",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                }
+            ],
+            "window": [0.008, 0.010],
+            "zeroTol": 0.005,  # Defines how close to zero the y value needs to be
+            "referenceValue": 0.00889, # u_f = 2*GYT/YT
+            "tolerance": 1e-5
+        },
+        {
+            "type": "max",
+            "identifier":
+                {
+                    "symbol": "SDV_COH_dmg",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 1.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "identifier":
+                {
+                    "symbol": "S22",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.1
+        }
+	]
+}

--- a/tests/test_COH2D4_shear.inp
+++ b/tests/test_COH2D4_shear.inp
@@ -1,0 +1,92 @@
+*Heading
+ Single cohesive element test for mode II response
+**
+*Parameter
+ length = 0.2
+ thickness = 0.0
+ displacement = 0.03
+ stepDuration = 0.1
+**
+*Node, nset=Nodes
+      1,            0.,            0.
+      2,      <length>,            0.
+      3,      <length>,      <thickness>
+      4,            0.,      <thickness>
+*Nset, nset=X+
+  2, 3
+*Nset, nset=X-
+  1, 4
+*Nset, nset=Y+
+  3, 4
+*Nset, nset=Y-
+  1, 2
+**
+*Element, type=COH2D4, elset=COHESIVE
+  1, 1, 2, 3, 4
+**
+*Cohesive Section, elset=COHESIVE, material=IM7-8552, response=TRACTION SEPARATION, thickness=SPECIFIED
+ 1.0,
+**
+*Material, name=IM7-8552
+*Density
+ 1.57e-09,
+*User material, constants=40
+** feature flags, ,   thickness, 4, 5, 6, 7, 8
+          200000, , <thickness>,  ,  ,  ,  ,  ,
+**  9         10        11        12        13        14        15        16
+**  E1,       E2,       G12,      nu12,     nu23,     YT,       SL        GYT
+      ,         ,          ,          ,         ,     62.3,     92.3,     0.277,
+**  17        18        19        20        21        22        23        24
+**  GSL,      eta_BK,   YC,       alpha0    E3,       G13,      G23,      nu13,
+    0.788,    1.634,    199.8,    0.925,    1.d6,        ,         ,          ,
+**  25        26        27        28        29        30        31        32
+**  alpha11,  alpha22,  alpha_PL, n_PL,     XT,       fXT,      GXT,      fGXT,
+           ,         ,          ,     ,       ,          ,         ,          ,
+**  33        34        35        36        37        38        39        40
+**  XC,       fXC,      GXC,      fGXC,     phi_ff,   w_kb,     phi0,     mu
+      ,          ,         ,          ,           ,       ,         ,     0.3
+*Depvar
+  19,
+  1, COH_dmg
+  2, COH_delta_s1
+  3, COH_delta_n
+  4, COH_delta_s2
+  5, COH_B
+  9, COH_FI
+ 15, COH_slide1
+ 16, COH_slide2
+** *Characteristic Length, definition=USER, components=2
+**
+*Initial Conditions, Type=Solution
+ COHESIVE,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Boundary
+  Y+, 2, 2, 0
+  Y-, 1, 2, 0
+**
+*Amplitude, name=LoadUp, definition=SMOOTH STEP
+ 0., 0., <stepDuration>, 1.
+**
+*Step, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+*Fixed Mass Scaling, factor=5000.
+**
+*Boundary, AMPLITUDE=LoadUp
+ Y+, 1, 1, <displacement>
+**
+*Output, FIELD
+*Element Output
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+*Node Output
+ U, RF
+*Output, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE, ALLPD
+*Node Output, NSET=Y+
+ U, RF
+*Element Output, ELSET=COHESIVE
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+**
+*End Step

--- a/tests/test_COH2D4_shear_compression.inp
+++ b/tests/test_COH2D4_shear_compression.inp
@@ -1,0 +1,114 @@
+*Heading
+ Single cohesive element with shear loading under normal compression
+**
+*Parameter
+ length = 0.2
+ thickness = 0.0
+ displacement = 0.03
+ stepDuration = 0.1
+ compressive_displacement = -0.00001
+**
+*Node, nset=Nodes
+      1,            0.,            0.
+      2,      <length>,            0.
+      3,      <length>,      <thickness>
+      4,            0.,      <thickness>
+*Nset, nset=X+
+  2, 3
+*Nset, nset=X-
+  1, 4
+*Nset, nset=Y+
+  3, 4
+*Nset, nset=Y-
+  1, 2
+**
+*Element, type=COH2D4, elset=COHESIVE
+  1, 1, 2, 3, 4
+**
+*Cohesive Section, elset=COHESIVE, material=IM7-8552, response=TRACTION SEPARATION, thickness=SPECIFIED
+ 1.0,
+**
+*Material, name=IM7-8552
+*Density
+ 1.57e-09,
+*User material, constants=40
+** feature flags, ,   thickness, 4, 5, 6, 7, 8
+          200000, , <thickness>,  ,  ,  ,  ,  ,
+**  9         10        11        12        13        14        15        16
+**  E1,       E2,       G12,      nu12,     nu23,     YT,       SL        GYT
+      ,         ,          ,          ,         ,     62.3,     92.3,     0.277,
+**  17        18        19        20        21        22        23        24
+**  GSL,      eta_BK,   YC,       alpha0    E3,       G13,      G23,      nu13,
+    0.788,    1.634,    199.8,    0.925,    1.d6,        ,         ,          ,
+**  25        26        27        28        29        30        31        32
+**  alpha11,  alpha22,  alpha_PL, n_PL,     XT,       fXT,      GXT,      fGXT,
+           ,         ,          ,     ,       ,          ,         ,          ,
+**  33        34        35        36        37        38        39        40
+**  XC,       fXC,      GXC,      fGXC,     phi_ff,   w_kb,     phi0,     mu
+      ,          ,         ,          ,           ,       ,         ,     0.3
+*Depvar
+  19,
+  1, COH_dmg
+  2, COH_delta_s1
+  3, COH_delta_n
+  4, COH_delta_s2
+  5, COH_B
+  9, COH_FI
+ 15, COH_slide1
+ 16, COH_slide2
+**
+*Initial Conditions, Type=Solution
+ COHESIVE,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Boundary
+  Y+, 1, 2, 0
+  Y-, 1, 2, 0
+**
+*Amplitude, name=LoadUp, definition=SMOOTH STEP
+ 0., 0., <stepDuration>, 1.
+**
+*Step, name=Compression, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+*Fixed Mass Scaling, factor=5000.
+**
+*Boundary, AMPLITUDE=LoadUp
+ Y+, 2, 2, <compressive_displacement>
+**
+*Output, FIELD
+*Element Output
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+*Node Output
+ U, RF
+*Output, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*Node Output, NSET=Y+
+ U, RF
+*Element Output, ELSET=COHESIVE
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+**
+*End Step
+
+*Step, name=Shear, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+**
+*Boundary, AMPLITUDE=LoadUp
+ Y+, 1, 1, <displacement>
+**
+*Output, FIELD
+*Element Output
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+*Node Output
+ U, RF
+*Output, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*Node Output, NSET=Y+
+ U, RF
+*Element Output, ELSET=COHESIVE
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+**
+*End Step

--- a/tests/test_COH2D4_shear_compression_expected.py
+++ b/tests/test_COH2D4_shear_compression_expected.py
@@ -1,0 +1,72 @@
+parameters = {
+	"results": [
+		{
+            "type": "min",
+            "step": "Compression",
+            "identifier":
+                {
+                    "symbol": "S22",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": -10.0,
+            "tolerance": 0.01
+        },
+		{
+            "type": "max",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 95.8,  # SL - 10.0 * SL/YC*cos(2.0*alpha0)/cos(alpha0)**2
+            "tolerance": 0.0958
+        },
+        {
+            "type": "disp_at_zero_y",
+            "step": "Shear",
+            "identifier": [
+                { # x
+                    "symbol": "U1",
+                    "nset": "Y+",
+                    "position": "Node 4"
+                },
+                { # y
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                }
+            ],
+            "window": [0.015, 0.020],
+            "zeroTol": 0.005,  # Defines how close to zero the y value needs to be
+            "referenceValue": 2.0*0.788/95.8,  # u_f = 2*GSL/(SL - 10.0 * SL/YC*cos(2.0*alpha0)/cos(alpha0)**2)
+            "tolerance": 1e-5
+        },
+        {
+            "type": "max",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "SDV_COH_dmg",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 1.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.2
+        }
+	]
+}

--- a/tests/test_COH2D4_shear_expected.py
+++ b/tests/test_COH2D4_shear_expected.py
@@ -1,0 +1,57 @@
+parameters = {
+	"results": [
+		{
+            "type": "max",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 92.3,  # SL
+            "tolerance": 0.0923
+        },
+        {
+            "type": "disp_at_zero_y",
+            "step": "Step-1",
+            "identifier": [
+                { # x
+                    "symbol": "U1",
+                    "nset": "Y+",
+                    "position": "Node 4"
+                },
+                { # y
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                }
+            ],
+            "window": [0.015, 0.020],
+            "zeroTol": 0.005,  # Defines how close to zero the y value needs to be
+            "referenceValue": 2.0*0.788/92.3,  # u_f = 2*GSL/SL
+            "tolerance": 1e-5
+        },
+        {
+            "type": "max",
+            "identifier":
+                {
+                    "symbol": "SDV_COH_dmg",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 1.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.2
+        }
+	]
+}

--- a/tests/test_COH2D4_shear_friction.inp
+++ b/tests/test_COH2D4_shear_friction.inp
@@ -1,0 +1,114 @@
+*Heading
+ Single cohesive element test for mode II response
+**
+*Parameter
+ length = 0.2
+ thickness = 0.0
+ displacement = 0.03
+ stepDuration = 0.1
+ compressive_displacement = -0.00001
+**
+*Node, nset=Nodes
+      1,            0.,            0.
+      2,      <length>,            0.
+      3,      <length>,      <thickness>
+      4,            0.,      <thickness>
+*Nset, nset=X+
+  2, 3
+*Nset, nset=X-
+  1, 4
+*Nset, nset=Y+
+  3, 4
+*Nset, nset=Y-
+  1, 2
+**
+*Element, type=COH2D4, elset=COHESIVE
+  1, 1, 2, 3, 4
+**
+*Cohesive Section, elset=COHESIVE, material=IM7-8552, response=TRACTION SEPARATION, thickness=SPECIFIED
+ 1.0,
+**
+*Material, name=IM7-8552
+*Density
+ 1.57e-09,
+*User material, constants=40
+** feature flags, ,   thickness, 4, 5, 6, 7, 8
+          200001, , <thickness>,  ,  ,  ,  ,  ,
+**  9         10        11        12        13        14        15        16
+**  E1,       E2,       G12,      nu12,     nu23,     YT,       SL        GYT
+      ,         ,          ,          ,         ,     62.3,     92.3,     0.277,
+**  17        18        19        20        21        22        23        24
+**  GSL,      eta_BK,   YC,       alpha0    E3,       G13,      G23,      nu13,
+    0.788,    1.634,    199.8,    0.925,    1.d6,        ,         ,          ,
+**  25        26        27        28        29        30        31        32
+**  alpha11,  alpha22,  alpha_PL, n_PL,     XT,       fXT,      GXT,      fGXT,
+           ,         ,          ,     ,       ,          ,         ,          ,
+**  33        34        35        36        37        38        39        40
+**  XC,       fXC,      GXC,      fGXC,     phi_ff,   w_kb,     phi0,     mu
+      ,          ,         ,          ,           ,       ,         ,     0.3
+*Depvar
+  19,
+  1, COH_dmg
+  2, COH_delta_s1
+  3, COH_delta_n
+  4, COH_delta_s2
+  5, COH_B
+  9, COH_FI
+ 15, COH_slide1
+ 16, COH_slide2
+**
+*Initial Conditions, Type=Solution
+ COHESIVE,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,  0.d0,
+            0.d0,  0.d0,  0.d0,  0.d0,  0.d0
+*Boundary
+  Y+, 1, 2, 0
+  Y-, 1, 2, 0
+**
+*Amplitude, name=LoadUp, definition=SMOOTH STEP
+ 0., 0., <stepDuration>, 1.
+**
+*Step, name=Compression, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+*Fixed Mass Scaling, factor=5000.
+**
+*Boundary, AMPLITUDE=LoadUp
+ Y+, 2, 2, <compressive_displacement>
+**
+*Output, FIELD
+*Element Output
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+*Node Output
+ U, RF
+*Output, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*Node Output, NSET=Y+
+ U, RF
+*Element Output, ELSET=COHESIVE
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+**
+*End Step
+
+*Step, name=Shear, nlgeom=YES
+*Dynamic, Explicit
+ , <stepDuration>, ,
+**
+*Boundary, AMPLITUDE=LoadUp
+ Y+, 1, 1, <displacement>
+**
+*Output, FIELD
+*Element Output
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+*Node Output
+ U, RF
+*Output, HISTORY, frequency=1
+*Energy Output
+ ALLIE, ALLKE
+*Node Output, NSET=Y+
+ U, RF
+*Element Output, ELSET=COHESIVE
+ SDV1, SDV2, SDV3, SDV4, SDV5, SDV9, SDV15, SDV16, S
+**
+*End Step

--- a/tests/test_COH2D4_shear_friction_expected.py
+++ b/tests/test_COH2D4_shear_friction_expected.py
@@ -1,0 +1,64 @@
+parameters = {
+	"results": [
+		{
+            "type": "min",
+            "step": "Compression",
+            "identifier":
+                {
+                    "symbol": "S22",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": -10.0,
+            "tolerance": 0.01
+        },
+		{
+            "type": "max",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 95.8,  # SL - 10.0 * SL/YC*cos(2.0*alpha0)/cos(alpha0)**2
+            "tolerance": 0.0958
+        },
+        {
+            "type": "finalValue",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 10.0*0.3,  # Compressive load * coefficient of friction
+            "tolerance": 0.03
+        },
+        {
+            "type": "max",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "SDV_COH_dmg",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 1.0,
+            "tolerance": 0.0
+        },
+        {
+            "type": "continuous",
+            "step": "Shear",
+            "identifier":
+                {
+                    "symbol": "S12",
+                    "elset": "COHESIVE",
+                    "position": "Element 1 Int Point 1"
+                },
+            "referenceValue": 0.0,
+            "tolerance": 0.2
+        }
+	]
+}

--- a/tests/test_COH3D8_fatigue_normal.inp
+++ b/tests/test_COH3D8_fatigue_normal.inp
@@ -3,14 +3,16 @@
 **
 *Parameter
 ** Input parameters
- length = 0.2
- thickness = 0.0
+ length = 0.1
+ th = 0.0  # thickness
  time_1 = 0.01
  time_2 = 0.02
  time_inc = 1.e-8
  stress_ratio = 0.5
- YT = 62.3
- SL = 92.3
+ YT = 80.1
+ SL = 97.6
+ GIc = 0.240
+ GIIc = 0.739
 ** Derived parameters
  applied_stress = YT * stress_ratio
  nodal_load = applied_stress * ( length * length ) / 4.
@@ -20,10 +22,10 @@
       2,      <length>,            0.,            0.
       3,      <length>,      <length>,            0.
       4,            0.,      <length>,            0.
-      5,            0.,            0.,   <thickness>
-      6,      <length>,            0.,   <thickness>
-      7,      <length>,      <length>,   <thickness>
-      8,            0.,      <length>,   <thickness>
+      5,            0.,            0.,          <th>
+      6,      <length>,            0.,          <th>
+      7,      <length>,      <length>,          <th>
+      8,            0.,      <length>,          <th>
 *Nset, nset=X+
   2, 3, 6, 7
 *Nset, nset=X-
@@ -52,20 +54,21 @@
 *Density
  1.57e-09,
 *User material, constants=40
-** feature flags, ,   thickness, 4, 5, 6, 7, 8
-          200000, , <thickness>,  ,  ,  ,  ,  ,
-**  9         10        11        12        13        14        15        16
-**  E1,       E2,       G12,      nu12,     nu23,     YT,       SL        GYT
-      ,         ,          ,          ,         ,   <YT>,      <SL>,     0.277,
-**  17        18        19        20        21        22        23        24
-**  GSL,      eta_BK,   YC,       alpha0    E3,       G13,      G23,      nu13,
-    0.788,    1.634,    199.8,    0.925,    1.d6,        ,         ,          ,
-**  25        26        27        28        29        30        31        32
-**  alpha11,  alpha22,  alpha_PL, n_PL,     XT,       fXT,      GXT,      fGXT,
-           ,         ,          ,     ,       ,          ,         ,          ,
-**  33        34        35        36        37        38        39        40
-**  XC,       fXC,      GXC,      fGXC,     phi_ff,   w_kb,     phi0,     mu
-      ,          ,         ,          ,           ,       ,         ,     0.3
+**  1              2        3          4       5          6        7        8
+**  feature flags,  ,       thickness,  ,      gamma_fat, eps_fat, eta_fat, p_fat,
+    200000,         ,       <th>,       ,      1.d7,      0.2,     0.95,    0.0,
+**  9              10       11         12      13         14       15       16
+**  E1,            E2,      G12,       nu12,   nu23,      YT,      SL,      GYT,
+      ,              ,         ,           ,       ,      <YT>,    <SL>,    <GIc>,
+**  17             18       19         20      21         22       23       24
+**  GSL,           eta_BK,  YC,        alpha0, E3,        G13,     G23,     nu13,
+    <GIIc>,        2.1,     199.8,     0.925,  2.d5,         ,        ,         ,
+**  25             26       27         28      29         30       31       32
+**  alpha11,       alpha22, alpha_PL,  n_PL,   XT,        fXT,     GXT,     fGXT,
+           ,              ,         ,      ,     ,           ,        ,         ,
+**  33             34       35         36      37         38       39       40
+**  XC,            fXC,     GXC,       fGXC,   phi_ff,    w_kb,    phi0,    mu
+      ,               ,        ,           ,         ,        ,        ,    0.0
 *Depvar
   19,
   1, COH_dmg

--- a/tests/test_COH3D8_fatigue_normal_expected.py
+++ b/tests/test_COH3D8_fatigue_normal_expected.py
@@ -1,7 +1,7 @@
 stress_ratio = 0.5
-strength = 62.3
-toughness = 0.277
-penalty = 1.e6
+strength = 80.1
+toughness = 0.240
+penalty = 2.e5
 
 delta_i = strength / penalty
 delta_f = 2.0 * toughness / strength
@@ -34,26 +34,6 @@ parameters = {
             "tolerance": strength * stress_ratio * 0.003
         },
         {
-            "type": "disp_at_zero_y",
-            "step": "Fatigue",
-            "identifier": [
-                { # x
-                    "symbol": "U3",
-                    "nset": "Z+",
-                    "position": "Node 5"
-                },
-                { # y
-                    "symbol": "S33",
-                    "elset": "COHESIVE",
-                    "position": "Element 1 Int Point 1"
-                }
-            ],
-            "window": [delta_f * 0.80, delta_f * 1.20],
-            "zeroTol": strength * 0.001,  # Defines how close to zero the y value needs to be
-            "referenceValue": delta_f,
-            "tolerance": delta_f * 0.1
-        },
-        {
             "type": "xy_infl_pt_bilinear",
             "step": "Fatigue",
             "identifier": [
@@ -73,7 +53,7 @@ parameters = {
 				delta_inflection_fatigue + (delta_f - delta_inflection_fatigue) * 0.80
 				],
             "referenceValue": [delta_inflection_fatigue, strength * stress_ratio],
-            "tolerance": [delta_inflection_fatigue * 0.01, strength * stress_ratio * 0.01],
+            "tolerance": [delta_inflection_fatigue * 0.02, strength * stress_ratio * 0.02],
         },
         {
             "type": "max",
@@ -86,18 +66,6 @@ parameters = {
                 },
             "referenceValue": 1.0,
             "tolerance": 0.0
-        },
-        {
-            "type": "continuous",
-			"step": "Fatigue",
-            "identifier":
-                {
-                    "symbol": "S33",
-                    "elset": "COHESIVE",
-                    "position": "Element 1 Int Point 1"
-                },
-            "referenceValue": 0.0,
-            "tolerance": strength * 0.1
         }
 	]
 }

--- a/tests/test_COH3D8_fatigue_shear13.inp
+++ b/tests/test_COH3D8_fatigue_shear13.inp
@@ -3,14 +3,16 @@
 **
 *Parameter
 ** Input parameters
- length = 0.2
- thickness = 0.0
+ length = 0.1
+ th = 0.0
  time_1 = 0.01
  time_2 = 0.02
  time_inc = 1.e-8
  stress_ratio = 0.5
- YT = 62.3
- SL = 92.3
+ YT = 80.1
+ SL = 97.6
+ GIc = 0.240
+ GIIc = 0.739
 ** Derived parameters
  applied_stress = SL * stress_ratio
  nodal_load = applied_stress * ( length * length ) / 4.
@@ -20,10 +22,10 @@
       2,      <length>,            0.,            0.
       3,      <length>,      <length>,            0.
       4,            0.,      <length>,            0.
-      5,            0.,            0.,   <thickness>
-      6,      <length>,            0.,   <thickness>
-      7,      <length>,      <length>,   <thickness>
-      8,            0.,      <length>,   <thickness>
+      5,            0.,            0.,          <th>
+      6,      <length>,            0.,          <th>
+      7,      <length>,      <length>,          <th>
+      8,            0.,      <length>,          <th>
 *Nset, nset=X+
   2, 3, 6, 7
 *Nset, nset=X-
@@ -52,20 +54,21 @@
 *Density
  1.57e-09,
 *User material, constants=40
-** feature flags, ,   thickness, 4, 5, 6, 7, 8
-          200000, , <thickness>,  ,  ,  ,  ,  ,
-**  9         10        11        12        13        14        15        16
-**  E1,       E2,       G12,      nu12,     nu23,     YT,       SL        GYT
-      ,         ,          ,          ,         ,     62.3,     92.3,     0.277,
-**  17        18        19        20        21        22        23        24
-**  GSL,      eta_BK,   YC,       alpha0    E3,       G13,      G23,      nu13,
-    0.788,    1.634,    199.8,    0.925,    1.d6,        ,         ,          ,
-**  25        26        27        28        29        30        31        32
-**  alpha11,  alpha22,  alpha_PL, n_PL,     XT,       fXT,      GXT,      fGXT,
-           ,         ,          ,     ,       ,          ,         ,          ,
-**  33        34        35        36        37        38        39        40
-**  XC,       fXC,      GXC,      fGXC,     phi_ff,   w_kb,     phi0,     mu
-      ,          ,         ,          ,           ,       ,         ,     0.3
+**  1              2        3          4       5          6        7        8
+**  feature flags,  ,       thickness,  ,      gamma_fat, eps_fat, eta_fat, p_fat,
+    200000,         ,       <th>,       ,      1.d7,      0.2,     0.95,    0.0,
+**  9              10       11         12      13         14       15       16
+**  E1,            E2,      G12,       nu12,   nu23,      YT,      SL,      GYT,
+      ,              ,         ,           ,       ,      <YT>,    <SL>,    <GIc>,
+**  17             18       19         20      21         22       23       24
+**  GSL,           eta_BK,  YC,        alpha0, E3,        G13,     G23,     nu13,
+    <GIIc>,        2.1,     199.8,     0.925,  2.d5,         ,        ,         ,
+**  25             26       27         28      29         30       31       32
+**  alpha11,       alpha22, alpha_PL,  n_PL,   XT,        fXT,     GXT,     fGXT,
+           ,              ,         ,      ,     ,           ,        ,         ,
+**  33             34       35         36      37         38       39       40
+**  XC,            fXC,     GXC,       fGXC,   phi_ff,    w_kb,    phi0,    mu
+      ,               ,        ,           ,         ,        ,        ,    0.0
 *Depvar
   19,
   1, COH_dmg

--- a/tests/test_COH3D8_fatigue_shear13_expected.py
+++ b/tests/test_COH3D8_fatigue_shear13_expected.py
@@ -1,7 +1,7 @@
 stress_ratio = 0.5
-strength = 92.3
-toughness = 0.788
-penalty = 1.e6 * 0.277 * strength * strength / (toughness * 62.3 * 62.3)
+strength = 97.6
+toughness = 0.739
+penalty = 2.e5 * 0.240 * strength * strength / (toughness * 80.1 * 80.1)
 
 delta_i = strength / penalty
 delta_f = 2.0 * toughness / strength
@@ -51,7 +51,7 @@ parameters = {
             "window": [delta_f * 0.80, delta_f * 1.20],
             "zeroTol": strength * 0.001,  # Defines how close to zero the y value needs to be
             "referenceValue": delta_f,
-            "tolerance": delta_f * 0.05
+            "tolerance": delta_f * 0.10
         },
         {
             "type": "xy_infl_pt_bilinear",
@@ -73,7 +73,7 @@ parameters = {
 				delta_inflection_fatigue + (delta_f - delta_inflection_fatigue) * 0.80
 				],
             "referenceValue": [delta_inflection_fatigue, strength * stress_ratio],
-            "tolerance": [delta_inflection_fatigue * 0.01, strength * stress_ratio * 0.01],
+            "tolerance": [delta_inflection_fatigue * 0.02, strength * stress_ratio * 0.02],
         },
         {
             "type": "max",
@@ -97,7 +97,7 @@ parameters = {
                     "position": "Element 1 Int Point 1"
                 },
             "referenceValue": 0.0,
-            "tolerance": strength * 0.1
+            "tolerance": strength * 0.15
         }
 	]
 }

--- a/tests/test_COH3D8_shear13_compression.inp
+++ b/tests/test_COH3D8_shear13_compression.inp
@@ -1,5 +1,5 @@
 *Heading
- Single cohesive element test for mode II response
+ Single cohesive element with longitudinal shear loading under normal compression
 **
 *Parameter
  length = 0.2

--- a/tests/test_COH3D8_shear23_compression.inp
+++ b/tests/test_COH3D8_shear23_compression.inp
@@ -1,5 +1,5 @@
 *Heading
- Single cohesive element test for mode II response
+ Single cohesive element with transverse shear loading under normal compression
 **
 *Parameter
  length = 0.2

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -525,6 +525,14 @@ class SingleElementCohesiveTests(av.TestCase):
 
     # -----------------------------------------------------------------------------------------
     # Test methods
+    def test_COH2D4_normal(self):
+        """ Single COH2D4 cohesive element test for normal loading """
+        self.runTest("test_COH2D4_normal")
+
+    def test_COH2D4_shear(self):
+        """ Single COH2D4 cohesive element test for shear loading """
+        self.runTest("test_COH2D4_shear")
+
     def test_COH3D8_normal(self):
         """ Single cohesive element test for mode I response """
         self.runTest("test_COH3D8_normal")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -526,12 +526,20 @@ class SingleElementCohesiveTests(av.TestCase):
     # -----------------------------------------------------------------------------------------
     # Test methods
     def test_COH2D4_normal(self):
-        """ Single COH2D4 cohesive element test for normal loading """
+        """ Single 2-D cohesive element test for normal loading """
         self.runTest("test_COH2D4_normal")
 
     def test_COH2D4_shear(self):
-        """ Single COH2D4 cohesive element test for shear loading """
+        """ Single 2-D cohesive element test for shear loading """
         self.runTest("test_COH2D4_shear")
+
+    def test_COH2D4_shear_compression(self):
+        """ Single 2-D cohesive element test for shear loading with normal compression """
+        self.runTest("test_COH2D4_shear_compression")
+
+    def test_COH2D4_shear_friction(self):
+        """ Single 2-D cohesive element test for shear loading with friction """
+        self.runTest("test_COH2D4_shear_friction")
 
     def test_COH3D8_normal(self):
         """ Single cohesive element test for mode I response """

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -267,7 +267,7 @@ class ParametricStressLife(av.TestCase):
 
     expectedpy_parameters = {'stress_ratio': parameters['stress_ratio']}
 
-    fatigue_R_ratio = 0.1
+    fatigue_R_ratio = 0.5
 
     # Class-wide methods
     @classmethod


### PR DESCRIPTION
- The cohesive fatigue law has been updated to the CF20 model introduced by Carlos Dávila et al in "Evaluation of Fatigue Damage Accumulation Functions for Delamination Initiation and Propagation," NASA/TP–2020-220584.
- The static cohesive damage equations have been refactored to remove some temporary variables and to enhance readability.
- Compatibility with two-dimensional COH2D4 cohesive elements has been added.